### PR TITLE
Fix servicemonitor's selector YAML

### DIFF
--- a/templates/servicemonitor.yml
+++ b/templates/servicemonitor.yml
@@ -12,7 +12,8 @@ spec:
   endpoints:
     {{- include "helpers.tplvalues.render" (dict "value" .endpoints "context" $) | nindent 4 }}
   selector:
-    {{- include "helpers.app.selectorLabels" $ | nindent 4 }}
-    {{- with $.Values.generic.extraSelectorLabels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end -}}
-    {{- with .extraSelectorLabels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end -}}
+    matchLabels:
+      {{- include "helpers.app.selectorLabels" $ | nindent 6 }}
+      {{- with $.Values.generic.extraSelectorLabels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}{{- end -}}
+      {{- with .extraSelectorLabels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}{{- end -}}
 {{- end -}}


### PR DESCRIPTION
Без этого патча не создавался сервисмонитор из-за невалидного ямла.