### PR TITLE
imagePullSecretsExtra parameter to use existing namespace pull secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | `secretEnvs`                | Map of environment variables which will be deplyed as Secret with name `RELEASE_NAME-secret-envs`             | `{}`             |
 | `secretEnvsString`          | String with map of environment variables which will be deplyed as Secret with name `RELEASE_NAME-secret-envs` | `""`             |
 | `imagePullSecrets`          | Map of registry secrets in `.dockerconfigjson` format                                                         | `{}`             |
+| `imagePullSecretsExtra`     | Array of existing pull secrets to add to each spec                                                            | `{}`             |
 | `defaultImage`              | Docker image that will be used by default                                                                     | `[]`             |
 | `defaultImageTag`           | Docker image tag that will be used by default                                                                 | `[]`             |
 | `defaultImagePullPolicy`    | Docker image pull policy that will be used by default                                                         | `"IfNotPresent"` |

--- a/samples/web-app.values.yml
+++ b/samples/web-app.values.yml
@@ -24,6 +24,10 @@ imagePullSecrets:
     {"auths":{"registry.org":{"auth":"cnd1c2VyOnNlY3VyZVBANXM="}}}
   registry.org-rw: b64:eyJhdXRocyI6eyJyZWdpc3RyeS5vcmciOnsiYXV0aCI6ImNuZDFjMlZ5T25ObFkzVnlaVkJBTlhNPSJ9fX0=
 
+# --set "imagePullSecretsExtra[0].name=$EXISTING_IMAGE_PULL_SECRET_NAME_ADD"
+imagePullSecretsExtra:
+  - name: existing-pull-secret
+
 defaultImage: registry.org/my-app
 defaultImageTag: latest
 

--- a/templates/cronjob.yml
+++ b/templates/cronjob.yml
@@ -112,12 +112,13 @@ spec:
           {{- with .tolerations }}
           tolerations: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 12 }}
           {{- end }}
-          {{ if or $.Values.imagePullSecrets .imagePullSecrets }}
+          {{ if or $.Values.imagePullSecrets .imagePullSecrets $.Values.imagePullSecretsExtra}}
           imagePullSecrets:
           {{- range $sName, $v := $.Values.imagePullSecrets }}
           - name: {{ $sName }}
           {{- end }}
           {{- with .imagePullSecrets }}{{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 10 }}{{- end }}
+          {{- with $.Values.imagePullSecretsExtra }}{{- toYaml . | nindent 10 }}{{- end }}
           {{- end }}
           {{- with .initContainers}}
           initContainers:

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -66,12 +66,13 @@ spec:
       {{- with .securityContext }}
       securityContext: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
       {{- end }}
-      {{ if or $.Values.imagePullSecrets .imagePullSecrets }}
+      {{ if or $.Values.imagePullSecrets .imagePullSecrets $.Values.imagePullSecretsExtra }}
       imagePullSecrets:
       {{- range $sName, $v := $.Values.imagePullSecrets }}
       - name: {{ $sName }}
       {{- end }}
       {{- with .imagePullSecrets }}{{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 6 }}{{- end }}
+      {{- with $.Values.imagePullSecretsExtra }}{{- toYaml . | nindent 6 }}{{- end }}
       {{- end }}
       {{- if .terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .terminationGracePeriodSeconds }}

--- a/templates/helm-hooks.yml
+++ b/templates/helm-hooks.yml
@@ -94,12 +94,13 @@ spec:
       {{- with .tolerations }}
       tolerations: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}
       {{- end }}
-      {{ if or $.Values.imagePullSecrets .imagePullSecrets }}
+      {{ if or $.Values.imagePullSecrets .imagePullSecrets $.Values.imagePullSecretsExtra}}
       imagePullSecrets:
       {{- range $sName, $v := $.Values.imagePullSecrets }}
       - name: {{ $sName }}
       {{- end }}
       {{- with .imagePullSecrets }}{{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 6 }}{{- end }}
+      {{- with $.Values.imagePullSecretsExtra }}{{- toYaml . | nindent 6 }}{{- end }}
       {{- end }}
       {{- with .initContainers}}
       initContainers:

--- a/templates/job.yml
+++ b/templates/job.yml
@@ -89,12 +89,13 @@ spec:
       {{- with .tolerations }}
       tolerations: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}
       {{- end }}
-      {{ if or $.Values.imagePullSecrets .imagePullSecrets }}
+      {{ if or $.Values.imagePullSecrets .imagePullSecrets $.Values.imagePullSecretsExtra}}
       imagePullSecrets:
       {{- range $sName, $v := $.Values.imagePullSecrets }}
       - name: {{ $sName }}
       {{- end }}
       {{- with .imagePullSecrets }}{{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 6 }}{{- end }}
+      {{- with $.Values.imagePullSecretsExtra }}{{- toYaml . | nindent 6 }}{{- end }}
       {{- end }}
       {{- with .initContainers}}
       initContainers:


### PR DESCRIPTION
Added `imagePullSecretsExtra` parameter which is useful when there is existing pull secret in namespace.