### PR TITLE
#47 - add CR to create certificates and issuers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 tmp/
 test*.yml
+private/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * deprecation: generic and workloads generals parameter `extraVolumeMounts` is marked as deprecated
 * fix: increased affinity weight for "soft" rules
 
+## 2.2.1 - Unreleased
+* feature: add `Certificate` and `Issuser/ClusterIssuer` rendering ([cert-manager](https://cert-manager.io/docs/reference/api-docs) resources)
+
 ## 2.2.0 - Feb 20, 2023
 
 * changed license to Apache2.0

--- a/samples/certificates.yml
+++ b/samples/certificates.yml
@@ -1,0 +1,41 @@
+
+generic:
+  # labels:
+  #   general-label1: general-label-value
+  # annotations:
+  #   general-annotation1: general-annotation-value
+
+issuerType: ClusterIssuer
+
+certificates:
+  sample-certificate:
+    secretName: sample-certificate
+    commonName: example.com
+    issuerRef:
+      originalName: selfsigned-issuer
+      kind: ClusterIssuer
+      group: cert-manager.io
+  sample-certificate2:
+    subject:
+      organizations:
+        - jetstack
+    dnsNames:
+      - example.com
+      - www.example.com
+    secretTemplate:
+      annotations:
+        www.example.com: example-annotation
+      labels:
+        www.example.com: example-label
+    isCA: "true"
+    issuerRef:
+      originalName: selfsigned-issuer
+      kind: "{{ .Values.issuerType }}"
+      # group: cert-manager.io
+
+######
+## run with:
+## helm template w --values ./samples/configmap-only.yml  ./charts/universal-chart/.  --debug
+##
+## result should be:
+######

--- a/samples/issuers.yml
+++ b/samples/issuers.yml
@@ -1,0 +1,99 @@
+
+generic:
+  # labels:
+  #   general-label1: general-label-value
+  # annotations:
+  #   general-annotation1: general-annotation-value
+
+issuerType: ClusterIssuer
+
+# certificates:
+#   sample-certificate:
+#     secretName: sample-certificate
+#     commonName: example.com
+#     isCA: "true"
+#     issuerRef:
+#       originalName: selfsigned-issuer
+#       kind: "{{ .Values.issuerType }}"
+
+secrets:
+  ca-key-pair:
+    data:
+      tls.crt: |-
+        -----BEGIN CERTIFICATE-----
+        MIIC+TCCAeGgAwIBAgIJAKPGwKDl/5HnMA0GCSqGSIb3DQEBCwUAMBMxETAPBgNV
+        BAMMCGpvc2h2YW5sMB4XDTE5MDgyMjE2MDU1OFoXDTI5MDgxOTE2MDU1OFowEzER
+        MA8GA1UEAwwIam9zaHZhbmwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+        AQCwhSB/qW6/kLb2zpu+EJvD9wHFaq+QA/0JH/Lllyo7zAFx+HHq+COAbk+C8B4t
+        /HUEsns5RL09CZ+X4j6pbJFdKduPxXu5ZVYnkxYpUDU7yg7OSKSZzTnIZ723sMs0
+        R6jYn/Drj4xXMJEfHUDqYeSWlZr3qi1EFa0c7fVDxH+4xtZtNNFOjH7c6D/vWkIg
+        WQUxiwusse6KMOWjDnv/4Vrjel2QgUYUbHCyeZHmcti+K0LWCfo/Rg6PulwrbDkh
+        jmOgYt30pdhX0OZkAuklfUDHfp8bjbCoI2taYABA6AKjKsO35LAEU79CL1mLVHuZ
+        ACI5Ujija3VPWVHSwmJPJyuxAgMBAAGjUDBOMB0GA1UdDgQWBBQml5dTAZixFKhj
+        93wucRWhao/tQjAfBgNVHSMEGDAWgBQml5dTAZixFKhj93wucRWhao/tQjAMBgNV
+        HRMEBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQB+klkRNJUKBLX8yYkyuU2RHcBv
+        GhmmDjJIsOJHZsoYXdLlG1pZNFjjPaOL8vh44Vl98RhEZBHsLT1KMbp1su6Cqj0r
+        UG1kpRBef+IOMT4MU7vRICi7UOlRLp1Wp0F8la3hPOcRb2yOfFqXXyZWXf4t0B45
+        tHi+ZCNHB9FxjSRycbGYVk+TKpvhJaSYNMGJ3dxDKaP7+Dx3XcK6sAnIAkhyI8aj
+        NU+mw8/tmRkP4In/kXAR+Ri0qUmHj/vwvnk4Km7ZUy1FYH8DMeS5Nksn+/uHlRxR
+        V7Dnn039TRmgKbAqN72gKNLo5cZ+y/YqDAYHYrn98SQT9JDgtI/K/ATpW8dX
+        -----END CERTIFICATE-----
+      tls.key: |-
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEowIBAAKCAQEAsIUgf6luv5C29s6bvhCbw/cBxWqvkAP9CR/y5ZcqO8wBcfhx
+        6vgjgG5PgvAeLfx1BLJ7OUS9PQmfl+I+qWyRXSnbj8V7uWVWJ5MWKVA1O8oOzkik
+        mc05yGe9t7DLNEeo2J/w64+MVzCRHx1A6mHklpWa96otRBWtHO31Q8R/uMbWbTTR
+        Tox+3Og/71pCIFkFMYsLrLHuijDlow57/+Fa43pdkIFGFGxwsnmR5nLYvitC1gn6
+        P0YOj7pcK2w5IY5joGLd9KXYV9DmZALpJX1Ax36fG42wqCNrWmAAQOgCoyrDt+Sw
+        BFO/Qi9Zi1R7mQAiOVI4o2t1T1lR0sJiTycrsQIDAQABAoIBACENHDOrFth5kTiP
+        IOwqke/UXRmIy0yM4qEFwWYpsre1kAO2ACZ9xa/zd6HNsejsX0C85oOnkkNOfPpk
+        W1U/xcwK3ViDIpJpHgOU785WfVEvmSwYv/EoUwxqGES/rpygWkYNVH/WxfFBX7rS
+        sGfyYmmro3OCAq2/3UUQbR7+OOfwy3HwTu0QunEJpEme6Ewsub0g8SLjvpJcHvSm
+        OBSJIrr/TcpTHN5OsXuVnENUjWpARdPOSkDVGmkBny2iVTDIROsFneuEFu6+W9jj
+        heoXM7g3nA46iKzu3GF0EhK8Y3Z4fxN64DdmcAZzaiMo0RUjKVLUjmYPHE1YfU+p
+        2CXowMECgYEA182iNvPI0UYViHynXJrSswV+q9SE+oV/tSfRQCFSllWGw+62nTbW
+        o5zh/TCAoUMSRmAOgLJYMKeFuIgoLJ17ZoZ3tSW3NUm2diOIOHz+q41C3904kS39
+        9+bAmVkZHP9VKK8C+i/mzNfJGGdBZtb0ykS3kw9B1LwgOz708EyqRCkCgYEA0WZP
+        o1v18gWkL+agP1o8Mwx4OfZS7wJcq4gLgQhca/iJKmcLtDSxqBGrBxQZ4Y22k9su
+        sLUk4BhliU3obQBMiGm0kHLuAHAQ6boufA1Bpf3vTWGJHRF4LxRl776jL8Qr8Vzq
+        ZTEPmcDtOHib7pob5gb3H8bThXyHftfqEnyjXEkCgYEAvOCt6YrVaNT+Y8c2dEbN
+        wwI8LAiFmv7dF6ER9B82OX4BxdtY2aD1m53j7cZVzs71X8MS7nEp3uvAjhIdl27+
+        Ym2uuE2aXHl3yU6wG0DLZTruHSFyMR8f+altSMpCwK55ynHjGTZzuzXiPAmjpG7f
+        MWmTgpMH+znsu+4OU4PGQoECgYAcjuGJm/8c9NwBlGiCe2H+bFLxRMDmy+GrmzBG
+        dsd0Cj9awxb7irw3+cDjhEBLXLJr09a4Ttwqm+ktIqzyQLovWItBsAr5kE8eMUAp
+        tv0fEFTUrtquVjWX5iZI3i0PVKfRkSR+jIReKcuwifJqRiZL5uNJOCqc5/DqwbOw
+        tcLp0QKBgEptL5IMtJNDBpWnYf7AyAPasDVDOZLHMPdi/go6+cJgiRkLakwyJcWr
+        SnPHmSlQ4hIn4c+5melpCXWIjIKD+cq9qOlfBdmikXodUCjjYBc6uFCT+5dd1c8G
+        bRBP9CmZOF/HNpst0H1zxMwW+Py9CegGxagFBzLsUo87LVGhtTQY
+        -----END RSA PRIVATE KEY-----
+
+issuers:
+  ca-issuer:
+    # kind: Issuer
+    ca:
+      secretName: ca-key-pair
+      # originalSecretName: selfsigned-issuer
+  selfsigned-issuer:
+    kind: "{{ .Values.issuerType }}"
+    selfSigned: {}
+  letsencrypt-staging:
+    kind: "{{ .Values.issuerType }}"
+    acme:
+      # The ACME server URL
+      server: https://acme-staging-v02.api.letsencrypt.org/directory
+      # Email address used for ACME registration
+      email: user@example.com
+      # Name of a secret used to store the ACME account private key
+      privateKeySecretRef:
+        name: letsencrypt-staging
+      # Enable the HTTP-01 challenge provider
+      solvers:
+      - http01:
+          ingress:
+            class: nginx
+######
+## run with:
+## helm template w --values ./samples/configmap-only.yml  ./charts/universal-chart/.  --debug
+##
+## result should be:
+######

--- a/samples/whoami-with-certs.yml
+++ b/samples/whoami-with-certs.yml
@@ -1,0 +1,75 @@
+deploymentsGeneral:
+  enableAffinity: false # default is true
+
+# nameOverride: whoami
+
+deployments:
+  whoami:
+    securityContext:
+      runAsUser: 1000
+      runAsGroup: 3000
+      fsGroup: 2000
+    containers:
+    - name: whoami
+      image: containous/whoami
+      imageTag: v1.5.0
+      resources:
+        limits:
+          cpu: 10m
+          memory: 128Mi
+        requests:
+          cpu: 1m
+          memory: 64Mi
+      args:
+        - --port
+        - "8080"
+      ports:
+        - name: web
+          containerPort: 8080
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+
+services:
+  whoami-web:
+    type: ClusterIP
+    ports:
+    - name: web
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+
+ingresses:
+  whoami.example.com:
+    hosts:
+    - paths:
+      - serviceName: whoami-web
+        servicePort: web
+    certManager:
+      issuerType: issuer
+      issuerName: selfsigned-ca-issuer
+      # originalIssuerName: letsencrypt
+
+issuerType: ClusterIssuer
+
+issuers:
+  selfsigned-issuer:
+    kind: "{{ .Values.issuerType }}"
+    selfSigned: {}
+  selfsigned-ca-issuer:
+    ca:
+      secretName: selfsigned-ca
+
+certificates:
+  selfsigned-ca:
+    isCA: true
+    commonName: selfsigned-ca
+    privateKey:
+      algorithm: ECDSA
+      size: 256
+    issuerRef:
+      name: selfsigned-issuer
+      kind: "{{ .Values.issuerType }}"
+
+# helm install f ./charts/universal-chart --values ./samples/whoami-with-certs.yml
+#

--- a/templates/certificate.yml
+++ b/templates/certificate.yml
@@ -1,0 +1,110 @@
+{{- if $.Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+{{- range $name, $cert := .Values.certificates }}
+{{- if not (.disabled | default false) }}
+
+---
+kind: Certificate
+apiVersion: cert-manager.io/v1
+metadata:
+  name: {{ include "helpers.app.fullname" (dict "name" $name "context" $) }}
+  labels:
+    {{- include "helpers.app.labels" $ | nindent 4 }}
+spec:
+  {{- with .subject }}
+  subject:
+    {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+  {{- with .literalSubject }}
+  literalSubject: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- with .commonName }}
+  commonName: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- with .duration }}
+  duration: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- with .renewBefore }}
+  renewBefore: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- if .dnsNames }}
+  dnsNames:
+  {{- range .dnsNames }}
+    - {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- end }}
+  {{- if .ipAddresses }}
+  ipAddresses:
+  {{- range .ipAddresses }}
+    - {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- end }}
+  {{- if .uris }}
+  uris:
+  {{- range .uris }}
+    - {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- end }}
+  {{- if .emailAddresses }}
+  emailAddresses:
+  {{- range .emailAddresses }}
+    - {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- end }}
+  {{- with .secretName }}
+  secretName: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- else }}
+  secretName: {{ include "helpers.app.fullname" (dict "name" $name "context" $) }}
+  {{- end }}
+  secretTemplate:
+    {{- if or (.secretTemplate).annotations ($.Values.generic).annotations }}
+    annotations:
+        {{- $_ := include "helpers.tplvalues.render" (dict "value" (default dict (.secretTemplate).annotations) "context" $) }}
+        {{- include "helpers.app.annotations" (dict "value" $_ "context" $) |  nindent 6  -}}
+    {{- end }}
+    labels:
+    {{- include "helpers.app.labels" $ | nindent 6 }}
+    {{- with (.secretTemplate).labels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}{{- end }}
+  {{- with .keystores }}
+  keystores:
+    {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+  {{- with .issuerRef }}
+  issuerRef:
+    {{- with .originalName }}
+    name: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+    {{- else }}
+    name: {{ include "helpers.app.fullname" (dict "name" .name "context" $) }}
+    {{- end }}
+    {{- with .kind }}
+    kind: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+    {{- end }}
+    {{- with .group }}
+    group: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+    {{- end }}
+  {{- end }}
+  {{- with .isCA }}
+  isCA: {{ . }}
+  {{- end }}
+  {{- if .usages }}
+  usages:
+  {{- range .usages }}
+    - {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- end }}
+  {{- with .privateKey }}
+  privateKey:
+    {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+  {{- with .encodeUsagesInRequest }}
+  encodeUsagesInRequest: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- with .revisionHistoryLimit }}
+  revisionHistoryLimit: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+  {{- end }}
+  {{- with .additionalOutputFormats }}
+  additionalOutputFormats:
+    {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/ingress.yml
+++ b/templates/ingress.yml
@@ -12,10 +12,14 @@ metadata:
     {{- include "helpers.app.genericAnnotations" $ | indent 4 }}
     {{- with $ing.certManager }}
     kubernetes.io/tls-acme: "true"
-    {{- if .issuerName }}
-    cert-manager.io/{{ .issuerType | default "cluster-issuer" }}: {{ .issuerName }}
-    {{- end }}
-    {{- end }}
+    {{- if or .issuerName .originalIssuerName }}
+    {{- if .originalIssuerName }}
+    cert-manager.io/{{ .issuerType | default "cluster-issuer" }}: {{ include "helpers.tplvalues.render" (dict "value" .originalIssuerName "context" $) }}
+    {{- else }}
+    cert-manager.io/{{ .issuerType | default "cluster-issuer" }}: {{ include "helpers.app.fullname" (dict "name" .issuerName "context" $) }}
+    {{- end }} {{/* end  if .originalIssuerName */}}
+    {{- end }} {{/* end  if or .issuerName .originalIssuerName */}}
+    {{- end }} {{/* end  $ing.certManager */}}
     {{- with $ing.annotations }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
 spec:
   {{- if and (eq "true" (include "helpers.ingress.supportsIngressClass" $)) ($ing.ingressClassName) }}

--- a/templates/issuer.yml
+++ b/templates/issuer.yml
@@ -1,0 +1,53 @@
+{{- if $.Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+{{- range $name, $iss := .Values.issuers }}
+{{- if not (.disabled | default false) }}
+{{- $_ := include "helpers.tplvalues.render" (dict "value" .kind "context" $) }}
+{{- $kind := ternary "ClusterIssuer" "Issuer" (eq $_ "ClusterIssuer") }}
+
+---
+kind: {{ $kind }}
+apiVersion: cert-manager.io/v1
+metadata:
+  name: {{ include "helpers.app.fullname" (dict "name" $name "context" $) }}
+  labels:
+    {{- include "helpers.app.labels" $ | nindent 4 }}
+spec:
+  {{- with .acme }}
+  acme:
+    {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+  {{- with .ca }}
+  ca:
+    {{- with .originalSecretName }}
+    secretName: {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+    {{- else }}
+    secretName: {{ include "helpers.app.fullname" (dict "name" .secretName "context" $) }}
+    {{- end }}
+    {{- if .crlDistributionPoints }}
+    crlDistributionPoints:
+    {{- range .crlDistributionPoints }}
+      - {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+    {{- end }}
+    {{- end }}
+    {{- if .ocspServers }}
+    ocspServers:
+    {{- range .ocspServers }}
+      - {{ include "helpers.tplvalues.render" (dict "value" . "context" $) }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- with .vault }}
+  vault:
+    {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if kindIs "map" .selfSigned }}
+  selfSigned:
+    {{- include "helpers.tplvalues.render" (dict "value" .selfSigned "context" $) | nindent 4 }}
+  {{- end }}
+  {{- with .venafi }}
+  venafi:
+    {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
+  {{- end }}
+{{- end }} {{/* end if not .disabled */}}
+{{- end }} {{/* end range */}}
+{{- end }}


### PR DESCRIPTION
- add template to create custom resources implements [Issuer](https://cert-manager.io/docs/concepts/issuer/) (ClusterIssuer also) and [Certificate](https://cert-manager.io/docs/concepts/certificate/) objects
- add simple web-application that creates this resources (create selfsigned issuer and certificate) and uses them as Ingress SSL certificate. To deploy it run `helm install f ./ --values ./samples/whoami-with-certs.yml`. 

For a test run next commands:
```
❯ cmctl status certificate f-whoami.example.com-tls
Name: f-whoami.example.com-tls
Namespace: default
Created at: 2023-05-02T22:54:00+03:00
Conditions:
  Ready: True, Reason: Ready, Message: Certificate is up to date and has not expired
DNS Names:
- whoami.example.com
Events:
  ...
Issuer:
  Name: f-selfsigned-ca-issuer
  Kind: Issuer
  Conditions:
    Ready: True, Reason: KeyPairVerified, Message: Signing CA verified
  Events:
    ...
Secret:
  Name: f-whoami.example.com-tls
  Issuer Country:
  Issuer Organisation:
  Issuer Common Name: selfsigned-ca
  Key Usage: Digital Signature, Key Encipherment
  Extended Key Usages:
  Public Key Algorithm: RSA
  Signature Algorithm: ECDSA-SHA256
  Subject Key ID:
  Authority Key ID: 862c30b38c6cdb81157cf1c08a0620b5b5dc3023
  Serial Number: d6a224f353104ea404a63f2792980966
  Events:  <none>
Not Before: 2023-05-02T22:54:06+03:00
Not After: 2023-07-31T22:54:06+03:00
Renewal Time: 2023-07-01T22:54:06+03:00
No CertificateRequest found for this Certificate

❯ certinfo --insecure whoami.example.com:443
--- [whoami.example.com:443 TLS 1.3] ---
Version: 3
Serial Number: 285296692633950831302078139990680275302
Signature Algorithm: ECDSA-SHA256
Type: end-entity
Issuer: CN=selfsigned-ca
Validity
    Not Before: May  2 19:54:06 2023 UTC
    Not After : Jul 31 19:54:06 2023 UTC
Subject:
DNS Names: whoami.example.com
IP Addresses:
Authority Key Id: 862c30b38c6cdb81157cf1c08a0620b5b5dc3023
Subject Key Id  :
Key Usage: Digital Signature, Key Encipherment
Ext Key Usage:
CA: false
```

First command get metadata about certificate from k8s resource via [cmctl](https://cert-manager.io/docs/reference/cmctl/) tool. The second one is [certinfo](https://github.com/pete911/certinfo) print information about certificate from the remote host (ingress). Identical values in the field `Authority Key Id` tell us that the certificates match.