### PR TITLE
Support loadBalancerClass, allocateLoadBalancerNodePorts and externalTrafficPolicy for LoadBalancer type services

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ the parameters that can be configured during installation. To check deployment e
 | `type`                     | Type of a service                                                     | `""`        |
 | `loadBalancerIP`           | IP of a service with LoadBalancer type                                | `""`        |
 | `loadBalancerSourceRanges` | Service Load Balancer sources                                         | `[]`        |
+| `loadBalancerClass`        | Service Load Balancer Class                                           | `""`        |
+| `allocateLoadBalancerNodePorts`  | Load Balancer NodePort allocation                               | `true`      |
 | `externalTrafficPolicy`    | Service external traffic policy                                       | `"Cluster"` |
 | `healthCheckNodePort`      | Health check node port (numeric port number) for the service          | ``          |
 | `externalIPs`              | Array of the external IPs that route to one or more cluster nodes     | `[]`        | 

--- a/templates/svc.yml
+++ b/templates/svc.yml
@@ -21,6 +21,17 @@ spec:
   {{- if not (empty .loadBalancerIP) }}
   loadBalancerIP: {{ .loadBalancerIP }}
   {{- end }}
+  {{- if not (empty .loadBalancerClass) }}
+  loadBalancerClass: {{ .loadBalancerClass }}
+  {{- end }}
+  {{- if not ( or (.allocateLoadBalancerNodePorts) (eq (.allocateLoadBalancerNodePorts | toString) "<nil>") ) }}
+  allocateLoadBalancerNodePorts: false
+  {{- end }}
+  {{- if empty .externalTrafficPolicy }}
+  externalTrafficPolicy: "Cluster"
+  {{- else }}
+  externalTrafficPolicy: {{ .externalTrafficPolicy }}
+  {{- end }}
   {{- if .loadBalancerSourceRanges }}
   loadBalancerSourceRanges:
     {{- toYaml .loadBalancerSourceRanges | nindent 4 }}


### PR DESCRIPTION
Support [loadBalancerClass](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class), [allocateLoadBalancerNodePorts](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation) and externalTrafficPolicy for LoadBalancer type services