### PR TITLE
render arrays in quoted comma-separated style for lifecycle hooks

### DIFF
--- a/templates/helpers/_pod.tpl
+++ b/templates/helpers/_pod.tpl
@@ -92,7 +92,7 @@ initContainers:
   ports: {{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 2 }}
   {{- end }}
   {{- with .lifecycle }}
-  lifecycle: {{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}
+  lifecycle: {{- include "helpers.tplvalues.renderWithCommaSeparatedArray" ( dict "value" . "context" $) | nindent 4 }}
   {{- end }}
   {{- with .startupProbe }}
   startupProbe: {{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}
@@ -142,7 +142,7 @@ containers:
   ports: {{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 2 }}
   {{- end }}
   {{- with .lifecycle }}
-  lifecycle: {{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}
+  lifecycle: {{- include "helpers.tplvalues.renderWithCommaSeparatedArray" ( dict "value" . "context" $) | nindent 4 }}
   {{- end }}
   {{- with .startupProbe }}
   startupProbe: {{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}

--- a/templates/helpers/_tplvalues.tpl
+++ b/templates/helpers/_tplvalues.tpl
@@ -5,3 +5,29 @@
 {{- tpl (.value | toYaml) .context }}
 {{- end }}
 {{- end -}}
+
+{{- define "helpers.tplvalues.renderWithCommaSeparatedArray" -}}
+{{- $value := .value -}}
+{{- $ctx := .context -}}
+{{- if typeIs "map[string]interface {}" $value -}}
+{{- range $k, $v := $value }}
+{{- printf "%s:" $k }}
+{{- $isArray := eq (include "helpers.tplvalues.isArray" $v) "true" -}}
+{{- $ind := 2 -}}
+{{- if not $isArray }}{{ print "\n" }}{{- end -}}
+{{- if $isArray }}{{ $ind = 1 }}{{- end -}}
+{{- (include "helpers.tplvalues.renderWithCommaSeparatedArray" (dict "value" $v "context" $ctx)) | indent $ind }}
+{{- end }}
+{{- else if eq (include "helpers.tplvalues.isArray" $value) "true" -}}
+[{{ range $index, $elem := $value }}{{ if $index }}, {{ end }}"{{ $elem }}"{{ end }}]
+{{- else if typeIs "string" .value }}
+{{- tpl $value $ctx }}
+{{- else }}
+{{- tpl ($value | toYaml) $ctx }}
+{{- end -}}
+{{- end -}}
+
+
+{{- define "helpers.tplvalues.isArray" -}}
+{{- typeIs "[]interface {}" . }}
+{{- end -}}


### PR DESCRIPTION
Hi, thanks for this Helm chart.

Here's my lifecycle hook in `values.yaml`:

```yaml
lifecycle:
  preStop:
    exec:
      command: ["/bin/bash", "-c", "PID=$(pidof java) && kill -SIGTERM $PID && while ps -p $PID > /dev/null; do sleep 1; done;"]
```

The `helpers.tplvalues.render` template generates incorrect YAML:

```yaml
lifecycle:
  preStop:
    exec:
      command:
      – /bin/bash
      – -c
      – PID=$(pidof java) && kill -SIGTERM $PID && while ps -p $PID > /dev/null; do sleep 
        1; done;
```

So I created a new template that converts to YAML but writes arrays in quoted, comma-separated style. This ensures that the rendered YAML is valid.