### PR TITLE
#77 Support for SealedSecrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.1 - September 04, 2024
+* feature: Implemented support for SealedSecrets ([#]https://github.com/nixys/nxs-universal-chart/issues/77)
+* docs update
+
 ## 2.8.0 - August 06, 2024
 * feature: Implemented native support for Istio resources. ([#71]https://github.com/nixys/nxs-universal-chart/issues/71)
 * docs update

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Nixys universal Helm chart for deploy your apps to Kubernetes
 name: universal-chart
-version: 2.8.0
+version: 2.8.1
 maintainers:
 - name: Roman Andreev
   email: r.andreev@nixys.io

--- a/README.md
+++ b/README.md
@@ -328,6 +328,16 @@ the parameters that can be configured during installation. To check deployment e
 
 Secret `data` object is a map where value can be a string, json or base64 encoded string with prefix `b64:`.
 
+### SealedSecrets paramaters
+
+`sealedSecrets` is a map of the SealedSecret parameters, where key is a name of SealedSecret.
+
+| Name               | Description                                  | Value      |
+|--------------------|----------------------------------------------|------------|
+| `labels`           | Extra SealedSecret labels                    | `{}`       | 
+| `annotations`      | Extra SealedSecret annotations               | `{}`       | 
+| `encryptedData`    | Map of SealedSecret encrypted data           | `{}`       |
+
 ### ConfigMaps parameters
 
 `configMaps` is a map of the ConfigMap parameters, where key is a name of ConfigMap.

--- a/docs/ADDITIONAL_FEATURES.md
+++ b/docs/ADDITIONAL_FEATURES.md
@@ -102,6 +102,29 @@ or
 --set-file "secrets.json-file.data.file\.json=path/to/file.json"
 ```
 
+#### SealedSecret
+
+Strings for SealedSecret are encrypted and not encoded to base64. To encrypt secret use `kubeseal` CLI:
+
+```bash
+kubeseal --raw --scope=namespace-wide --namespace=yournamespace --from-file=yoursecret.txt
+```
+
+Values file:
+
+```yaml
+sealedSecrets:
+  secretname:
+    encryptedData:
+      FOO: "encrypted-secret-string"
+```
+
+`--set` analog:
+
+```bash
+--set "sealedSecrets.secretname.encryptedData.FOO=$SOME_ENV_WITH_STRING"
+```
+
 ### Values Templating features
 
 You can use go-templates as part of your values.

--- a/templates/helpers/_secrets.tpl
+++ b/templates/helpers/_secrets.tpl
@@ -54,3 +54,15 @@
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "helpers.secrets.renderSealed" -}}
+{{- $v := dict -}}
+{{- if kindIs "string" .value -}}
+{{- $v = fromYaml .value }}
+{{- else -}}
+{{- $v = .value }}
+{{- end -}}
+{{- range $key, $value := $v }}
+{{ printf "%s: %s" $key $value }}
+{{- end -}}
+{{- end -}}

--- a/templates/secret.yml
+++ b/templates/secret.yml
@@ -46,3 +46,30 @@ metadata:
 data:
   {{- include "helpers.secrets.render" (dict "value" (printf ".dockerconfigjson: %v" $value)) | indent 2 }}
 {{- end }}
+
+{{- range $sName, $val := .Values.sealedSecrets -}}
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: {{ include "helpers.app.fullname" (dict "name" $sName "context" $) }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    {{- include "helpers.app.labels" $ | nindent 4 }}
+    {{- with $val.labels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{ end }}
+  annotations:
+    {{- include "helpers.app.hooksAnnotations" $ | nindent 4 }}
+    {{- with $val.annotations }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{ end }}
+spec:
+  encryptedData:
+    {{- include "helpers.secrets.renderSealed" (dict "value" $val.encryptedData) | indent 4 }}
+  template:
+    metadata:
+      name: {{ include "helpers.app.fullname" (dict "name" $sName "context" $) }}
+      namespace: {{ $.Release.Namespace | quote }}
+      labels:
+        {{- include "helpers.app.labels" $ | nindent 8 }}
+        {{- with $val.labels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}{{ end }}
+      annotations:
+        {{- with $val.annotations }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}{{ end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -246,6 +246,13 @@ secrets: {}
   #      "arg": "value"
   #    }
 
+sealedSecrets: {}
+  # test:
+  #   encryptedData:
+  #     foo: Yy3LvlaCgEWV50VrNY4Aow/X
+  #     bar: |-
+  #       fjVmoxIulUKX5IAserbCpw/Y
+
 configMaps: {}
   #some-cm:
   #  labels:


### PR DESCRIPTION
SealedSecrets allows you to store secrets in a git repository and safely include them in values for a Helm chart. Support for SealedSecrets simplifies the usage of this chart with GitOps tools like Flux CD or Argo CD.

We've added support for SealedSecrets in our project and tested it with our services and Flux CD.

