### PR TITLE
feat: make progressDeadlineSeconds configurable in deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.8.1 - November 18, 2024
+* feature: make `progressDeadlineSeconds` configurable in deployments
+
 ## 2.8.0 - August 06, 2024
 * feature: Implemented native support for Istio resources. ([#71]https://github.com/nixys/nxs-universal-chart/issues/71)
 * docs update

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Nixys universal Helm chart for deploy your apps to Kubernetes
 name: universal-chart
-version: 2.8.0
+version: 2.8.1
 maintainers:
 - name: Roman Andreev
   email: r.andreev@nixys.io

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ the parameters that can be configured during installation. To check deployment e
 | `annotations`                   | Extra annotations for deployment                                                                                                  | `{}`  |
 | `replicas`                      | Deployment replicas count                                                                                                         | `1`   |
 | `strategy`                      | Deployment strategy                                                                                                               | `{}`  |
+| `progressDeadlineSeconds`       | The maximum time in seconds for a deployment to make progress before it is considered failed | `600`  |
 | `extraSelectorLabels`           | Extra selectorLabels for deployment                                                                                               | `{}`  |
 | `podLabels`                     | Extra pod labels for deployment                                                                                                   | `{}`  |
 | `podAnnotations`                | Extra pod annotations for deployment                                                                                              | `{}`  |

--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -20,6 +20,7 @@ spec:
   {{- with .strategy }}
   strategy: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
+  progressDeadlineSeconds: {{ .progressDeadlineSeconds | default 600 }}
   selector:
     matchLabels:
       {{- include "helpers.app.selectorLabels" $ | nindent 6 }}


### PR DESCRIPTION
### Problem

The Helm chart did not include support for the `progressDeadlineSeconds` field in Deployment templates. This meant users could not configure the timeout for detecting progress in rolling updates.

### Solution

- Added support for the `progressDeadlineSeconds` field in the `deployment.yml` template.
- Made the field configurable through `values.yaml`, with a default value of `600 seconds`.

### Testing

1. **Default Behavior**:
   - Deployed the chart without setting `progressDeadlineSeconds` in `values.yaml`.
   - Verified that the Kubernetes manifest included the default value (`600 seconds`).

2. **Custom Configuration**:
   - Set a custom `progressDeadlineSeconds` value in `values.yaml`:
     ```yaml
     deployments:
       app:
         progressDeadlineSeconds: 3600
     ```
   - Verified that the Kubernetes manifest reflected the specified value.

3. **Linting and Validation**:
   - Ran `helm lint` to ensure no syntax or structural issues.
   - Deployed to a Kubernetes cluster and confirmed that the field was applied correctly.

### Notes

- The field is optional, with a fallback to `600 seconds` if not specified.
- No impact on existing functionality for users who do not set this field.