### PR TITLE
fix README miss spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.8.4 - January 27, 2025
+* fix: Fixed `global.apiVersions` key miss spelling in README.md
+
 ## 2.8.3 - December 26, 2024
 * feature: Made `progressDeadlineSeconds` configurable in deployments
 

--- a/README.md
+++ b/README.md
@@ -44,19 +44,19 @@ the parameters that can be configured during installation. To check deployment e
 
 ### Global parameters
 
-| Name                                     | Description                                              | Value |
-|------------------------------------------|----------------------------------------------------------|-------|
-| `global.kubeVersion`                     | Global Override Kubernetes version                       | `""`  |
-| `global.helmVersion`                     | Global Override Helm version                             | `""`  |
-| `global.apiVersion.cronJob`              | Global Override CronJob API version                      | `""`  |
-| `global.apiVersion.deployment`           | Global Override Deployment API version                   | `""`  |
-| `global.apiVersion.statefulSet`          | Global Override StatefulSet API version                  | `""`  |
-| `global.apiVersion.ingress`              | Global Override Ingress API version                      | `""`  |
-| `global.apiVersion.pdb`                  | Global Override PodDisruptionBudget API version          | `""`  |
-| `global.apiVersion.traefik`              | Global Override Traefik resources API version            | `""`  |
-| `global.apiVersion.istioGateway`         | Global Override Istio Gateway API version                | `""`  |
-| `global.apiVersion.istioVirtualService`  | Global Override Istio VirtualService API version         | `""`  |
-| `global.apiVersion.istioDestinationRule` | Global Override Istio DestinationRule API version        | `""`  |
+| Name                                      | Description                                              | Value |
+|-------------------------------------------|----------------------------------------------------------|-------|
+| `global.kubeVersion`                      | Global Override Kubernetes version                       | `""`  |
+| `global.helmVersion`                      | Global Override Helm version                             | `""`  |
+| `global.apiVersions.cronJob`              | Global Override CronJob API version                      | `""`  |
+| `global.apiVersions.deployment`           | Global Override Deployment API version                   | `""`  |
+| `global.apiVersions.statefulSet`          | Global Override StatefulSet API version                  | `""`  |
+| `global.apiVersions.ingress`              | Global Override Ingress API version                      | `""`  |
+| `global.apiVersions.pdb`                  | Global Override PodDisruptionBudget API version          | `""`  |
+| `global.apiVersions.traefik`              | Global Override Traefik resources API version            | `""`  |
+| `global.apiVersions.istioGateway`         | Global Override Istio Gateway API version                | `""`  |
+| `global.apiVersions.istioVirtualService`  | Global Override Istio VirtualService API version         | `""`  |
+| `global.apiVersions.istioDestinationRule` | Global Override Istio DestinationRule API version        | `""`  |
 
 ### Generic parameters
 


### PR DESCRIPTION
In the documentation, the path in values.yaml to change the apiVersion was incorrect, because in [templates/helpers/_capabilities.tpl](https://github.com/nixys/nxs-universal-chart/blob/4a0232cd99c7eb7587893e90362a78bec33e7efc/templates/helpers/_capabilities.tpl#L43) `.Values.global.apiVersions` is used everywhere, not `.Values.global.apiVersion`