### PR TITLE
Pass $general env vars to init container

### DIFF
--- a/templates/helpers/_pod.tpl
+++ b/templates/helpers/_pod.tpl
@@ -90,8 +90,8 @@ initContainers:
   command: {{- include "helpers.tplvalues.render" ( dict "value" .command "context" $) | nindent 2 }}
   {{- end }}
   {{- end }}
-  {{- include "helpers.workloads.envs" (dict "value" . "context" $) | indent 2 }}
-  {{- include "helpers.workloads.envsFrom" (dict "value" . "context" $) | indent 2 }}
+  {{- include "helpers.workloads.envs" (dict "value" . "general" $general "context" $) | indent 2 }}
+  {{- include "helpers.workloads.envsFrom" (dict "value" . "general" $general "context" $) | indent 2 }}
   {{- with .ports }}
   ports: {{- include "helpers.tplvalues.render" ( dict "value" . "context" $) | nindent 2 }}
   {{- end }}


### PR DESCRIPTION
! Potentially breaking change

- Pass $general env/envFrom values to initContainers
- If you're upgrading to this version, ensure your initContainers won't be affected by envs configured in $general

I needed to pass $general environment config to my initcontainer, so I made a change to support that. This is potentially breaking as it may cause conflicts with existing env vars sharing the names that would be injected by templating.

See [this comment](https://github.com/nixys/nxs-universal-chart/pull/87#issue-3130936060) for how to view/test the output