### PR TITLE
feat: add VMServiceScrape support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.8.4 - Unreleased
+* feature: Added support for VMServiceScrape (VictoriaMetrics ServiceMonitor equivalent)
+
 ## 2.8.3 - December 26, 2024
 * feature: Made `progressDeadlineSeconds` configurable in deployments
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Who deploy into Kubernetes/OpenShift on regular basis.
       - [Hooks parameters](#hooks-parameters)
     - Prometheus-operator resources
       - [ServiceMonitors parameters](#servicemonitors-parameters)
+    - VictoriaMetrics-operator resources
+      - [VMServiceScrapes parameters](#vmservicescrapes-parameters)
     - Cert-manager resources
       - [Issuers parameters](#issuers-parameters)
       - [Certificates parameters](#certificates-parameters)
@@ -625,6 +627,20 @@ Secret `data` object is a map where value can be a string, json or base64 encode
 | `labels`              | Extra ServiceMonitor labels              | `{}`  |
 | `endpoints`           | Array of ServiceMonitor endpoints        | `[]`  |
 | `extraSelectorLabels` | Extra selectorLabels for select workload | `{}`  |
+
+### VMServiceScrapes parameters
+
+`vmServiceScrapes` is a map of the VictoriaMetrics VMServiceScrape parameters, where key is name of VMServiceScrape.
+
+| Name                  | Description                              | Value |
+|-----------------------|------------------------------------------|-------|
+| `labels`              | Extra VMServiceScrape labels             | `{}`  |
+| `endpoints`           | Array of VMServiceScrape endpoints       | `[]`  |
+| `extraSelectorLabels` | Extra selectorLabels for select workload | `{}`  |
+| `sampleLimit`         | Maximum number of samples to scrape per target | `""`  |
+| `streamParse`         | Enable streaming parsing for better performance | `""`  |
+
+**Note:** VMServiceScrape is the VictoriaMetrics equivalent of ServiceMonitor and provides additional features specific to VictoriaMetrics ecosystem.
 
 ### PodDisruptionBudget parameters
 

--- a/docs/samples/vmservicescrape.values.yml
+++ b/docs/samples/vmservicescrape.values.yml
@@ -1,0 +1,55 @@
+# Example configuration for VMServiceScrape
+# This file demonstrates how to configure VMServiceScrape for VictoriaMetrics
+
+# VMServiceScrape configuration
+vmServiceScrapes:
+  app-vms:
+    endpoints:
+    - interval: 30s
+      port: exporter
+      path: /metrics
+      # Additional VMServiceScrape specific options
+      # scrapeTimeout: 10s
+      # honorLabels: true
+      # honorTimestamps: true
+      # metricRelabelings:
+      # - sourceLabels: [__name__]
+      #   regex: 'node_(.+)'
+      #   targetLabel: node_metric
+      #   replacement: '${1}'
+    extraSelectorLabels:
+      app: nginx
+    labels:
+      foo: foo
+      # VMServiceScrape specific labels
+      # vm_service_scrape: "true"
+    # VMServiceScrape specific parameters
+    sampleLimit: 1000  # Maximum number of samples to scrape per target
+    streamParse: true  # Enable streaming parsing for better performance
+
+# You can also use the alternative key name (lowercase)
+vmservicescrapes:
+  app-vms-alt:
+    endpoints:
+    - interval: 15s
+      port: metrics
+      path: /metrics
+      # VMServiceScrape supports additional features compared to ServiceMonitor
+      # - scrapeTimeout: 10s
+      # - honorLabels: true
+      # - honorTimestamps: true
+      # - followRedirects: true
+      # - enableHttp2: true
+      # - tlsConfig:
+      #     insecureSkipVerify: true
+      # - basicAuth:
+      #     username:
+      #       name: basic-auth
+      #       key: username
+      #     password:
+      #       name: basic-auth
+      #       key: password
+    extraSelectorLabels:
+      app: myapp
+    labels:
+      vm_service_scrape: "true" 

--- a/templates/vmservicescrape.yml
+++ b/templates/vmservicescrape.yml
@@ -1,0 +1,51 @@
+{{- range $name, $sm := .Values.vmServiceScrapes }}
+---
+kind: VMServiceScrape
+apiVersion: operator.victoriametrics.com/v1beta1
+metadata:
+  name: {{ include "helpers.app.fullname" (dict "name" $name "context" $) }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    {{- include "helpers.app.labels" $ | nindent 4 }}
+    {{- with .labels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
+spec:
+  endpoints:
+    {{- include "helpers.tplvalues.render" (dict "value" .endpoints "context" $) | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "helpers.app.selectorLabels" $ | nindent 6 }}
+      {{- with $.Values.generic.extraSelectorLabels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}{{- end -}}
+      {{- with .extraSelectorLabels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}{{- end -}}
+  {{- with .sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
+  {{- with .streamParse }}
+  streamParse: {{ . }}
+  {{- end }}
+{{- end }}
+
+{{- range $name, $sm := .Values.vmservicescrapes }}
+---
+kind: VMServiceScrape
+apiVersion: operator.victoriametrics.com/v1beta1
+metadata:
+  name: {{ include "helpers.app.fullname" (dict "name" $name "context" $) }}
+  namespace: {{ $.Release.Namespace | quote }}
+  labels:
+    {{- include "helpers.app.labels" $ | nindent 4 }}
+    {{- with .labels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
+spec:
+  endpoints:
+    {{- include "helpers.tplvalues.render" (dict "value" .endpoints "context" $) | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "helpers.app.selectorLabels" $ | nindent 6 }}
+      {{- with $.Values.generic.extraSelectorLabels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}{{- end -}}
+      {{- with .extraSelectorLabels }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 6 }}{{- end -}}
+  {{- with .sampleLimit }}
+  sampleLimit: {{ . }}
+  {{- end }}
+  {{- with .streamParse }}
+  streamParse: {{ . }}
+  {{- end }}
+{{- end }} 

--- a/values.yaml
+++ b/values.yaml
@@ -341,6 +341,19 @@ serviceMonitors: {}
 #    labels:
 #      foo: foo
 
+vmServiceScrapes: {}
+#  app-vms:
+#    endpoints:
+#    - interval: 30s
+#      port: exporter
+#      path: /metrics
+#    extraSelectorLabels:
+#      app: nginx
+#    labels:
+#      foo: foo
+#    sampleLimit: 1000
+#    streamParse: true
+
 extraDeploy: {}
 #  net-pol: |-
 #    apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
# Add VMServiceScrape support for VictoriaMetrics

## Description
Adds native support for VMServiceScrape resources - the VictoriaMetrics equivalent of Prometheus ServiceMonitor with additional VM-specific features.

## Features
- Support for `vmServiceScrapes` and `vmservicescrapes` keys
- All standard ServiceMonitor parameters
- VM-specific parameters: `sampleLimit`, `streamParse`

## Usage
```yaml
vmServiceScrapes:
  app-vms:
    endpoints:
    - interval: 30s
      port: exporter
      path: /metrics
    sampleLimit: 1000
    streamParse: true
```