### PR TITLE
Honor replicas: 0 in Deployments / Statefulset (use dig instead of default; nil-safe maps)

### DIFF
--- a/templates/deployment.yml
+++ b/templates/deployment.yml
@@ -16,7 +16,7 @@ metadata:
     {{- with $general.annotations }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
     {{- with .annotations }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
 spec:
-  replicas: {{ .replicas | default 1 }}
+  replicas:  {{ dig "replicas" (dig "replicas" 1 $general) $d | int }}
   {{- with .strategy }}
   strategy: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}

--- a/templates/statefulset.yml
+++ b/templates/statefulset.yml
@@ -15,7 +15,7 @@ metadata:
     {{- include "helpers.app.genericAnnotations" $ | indent 4 }}
     {{- with .annotations }}{{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}{{- end }}
 spec:
-  replicas: {{ .replicas | default 1 }}
+  replicas: {{ dig "replicas" (dig "replicas" 1 $general) $sts | int }}
   {{- with .strategy }}
   strategy: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}


### PR DESCRIPTION
This PR fixes a templating issue where setting replicas: 0 for a Deployment is ignored and falls back to 1. The chart previously used default (or equivalent) which treats numeric 0 as “empty.” This change switches to dig with nil-safe guards so an explicit zero is honored. It also makes the .disabled guard truthy-safe and allows a global fallback via deploymentsGeneral.replicas.

Why

Bug: Users cannot scale a Deployment to zero; replicas: 0 renders as 1.

Expected: Kubernetes supports zero replicas; Helm templates should render 0 when explicitly set.

Side benefit: Prevents panics when .Values.deployments or .Values.deploymentsGeneral are missing (nil).