### PR TITLE
fix: quote hostname values in Ingress template to support wildcards

### DIFF
--- a/templates/ingress.yml
+++ b/templates/ingress.yml
@@ -28,9 +28,9 @@ spec:
   rules:
   {{- range $ing.hosts }}
   - {{ if .hostname -}}
-    host: {{ include "helpers.tplvalues.render" (dict "value" .hostname "context" $) }}
+    host: {{ include "helpers.tplvalues.render" (dict "value" .hostname "context" $) | quote }}
     {{- else -}}
-    host: {{ $host }}
+    host: {{ $host | quote }}
     {{- end }}
     http:
       paths:
@@ -49,9 +49,9 @@ spec:
   - hosts:
     {{- range $ing.hosts }}
     {{- if .hostname }}
-    - {{ include "helpers.tplvalues.render" (dict "value" .hostname "context" $) }}
+    - {{ include "helpers.tplvalues.render" (dict "value" .hostname "context" $) | quote }}
     {{- else }}
-    - {{ $host }}
+    - {{ $host | quote }}
     {{- end }}
     {{- end }}
     secretName: {{ .tlsName | default (include "helpers.app.fullname" (dict "name" ($ing.name | default $host) "context" $)) }}-tls


### PR DESCRIPTION
- Add | quote filter to hostname values in ingress rules and TLS sections
- Fixes YAML parse error when using wildcard hostnames like *.example.com
- Resolves issue where asterisk in hostname caused 'did not find expected alphabetic or numeric character' error
- Ensures all hostname values are properly quoted for safe YAML generation

Fixes #86