### PR TITLE
`autoRolloutChecksums` now generates only referenced configMaps/secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.1.0] - ???
+### Changed
+* `autoRolloutChecksums` now generates checksum annotations only for ConfigMaps, Secrets, and SealedSecrets that are actually referenced by a given workload (via `envConfigmaps`, `envSecrets`, `envsFromConfigmap`, `envsFromSecret`, or typed `volumes`), instead of checksumming every resource in the release. Global `envs`/`secretEnvs` checksums remain on all workloads.
+
 ## [3.0.8] - April 13, 2026
 ### Added
 * added `stdin` and `tty` support for containers and initContainers

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: nxs-universal-chart
 description: Helm chart for rendering reusable Kubernetes application resources
 type: application
-version: 3.0.8
+version: 3.1.0
 appVersion: "v1"
 icon: https://registry.nixys.ru/logo.png
 home: https://github.com/nixys/nxs-universal-chart

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Schema matching note:
 | `generic.fullnameOverride` | `generic.fullnameOverride: "platform-core"` | `""` | Deterministic base name override for all resources. |
 | `generic.nameSuffix` | `generic.nameSuffix: "blue"` | `""` | Suffix appended to deterministic base name. |
 | `generic.deterministicNames` | `generic.deterministicNames: true` | `true` | Enables deterministic fallback names for unnamed containers/initContainers. |
-| `generic.autoRolloutChecksums` | `generic.autoRolloutChecksums: true` | `true` | Adds checksum pod annotations for managed ConfigMaps/Secrets. |
+| `generic.autoRolloutChecksums` | `generic.autoRolloutChecksums: true` | `true` | Adds checksum pod annotations for ConfigMaps/Secrets referenced by each workload. |
 | `generic.extraSelectorLabels` | `generic.extraSelectorLabels.tenant: "shared"` | `{}` | Extra labels merged into selectors and pod labels. |
 | `generic.podLabels` | `generic.podLabels.tier: "backend"` | `{}` | Labels applied to all workload pod templates. |
 | `generic.podAnnotations` | `generic.podAnnotations.rendered-from: "values"` | `{}` | Annotations applied to all workload pod templates. |

--- a/docs/README.md.gotmpl
+++ b/docs/README.md.gotmpl
@@ -177,7 +177,7 @@ Schema matching note:
 | `generic.fullnameOverride` | `generic.fullnameOverride: "platform-core"` | `""` | Deterministic base name override for all resources. |
 | `generic.nameSuffix` | `generic.nameSuffix: "blue"` | `""` | Suffix appended to deterministic base name. |
 | `generic.deterministicNames` | `generic.deterministicNames: true` | `true` | Enables deterministic fallback names for unnamed containers/initContainers. |
-| `generic.autoRolloutChecksums` | `generic.autoRolloutChecksums: true` | `true` | Adds checksum pod annotations for managed ConfigMaps/Secrets. |
+| `generic.autoRolloutChecksums` | `generic.autoRolloutChecksums: true` | `true` | Adds checksum pod annotations for ConfigMaps/Secrets referenced by each workload. |
 | `generic.extraSelectorLabels` | `generic.extraSelectorLabels.tenant: "shared"` | `{}` | Extra labels merged into selectors and pod labels. |
 | `generic.podLabels` | `generic.podLabels.tier: "backend"` | `{}` | Labels applied to all workload pod templates. |
 | `generic.podAnnotations` | `generic.podAnnotations.rendered-from: "values"` | `{}` | Annotations applied to all workload pod templates. |

--- a/templates/_compat.tpl
+++ b/templates/_compat.tpl
@@ -202,6 +202,50 @@ false
 {{ toYaml $ports }}
 {{- end -}}
 
+{{- define "helpers.workloads.referencedResources" -}}
+{{- $ctx := .context -}}
+{{- $general := .general | default dict -}}
+{{- $value := .value | default dict -}}
+{{- $referencedConfigMaps := dict -}}
+{{- $referencedSecrets := dict -}}
+{{- /* Collect referenced names from all containers and initContainers */ -}}
+{{- $containers := list -}}
+{{- $containers = concat $containers (fromYamlArray (include "helpers.workloads.containerEntries" (dict "value" $value.containers)) | default list) -}}
+{{- $containers = concat $containers (fromYamlArray (include "helpers.workloads.containerEntries" (dict "value" $value.initContainers)) | default list) -}}
+{{- range $container := $containers -}}
+  {{- /* envConfigmaps: list of configmap names */ -}}
+  {{- range (get $container "envConfigmaps" | default list) -}}
+    {{- $_ := set $referencedConfigMaps . true -}}
+  {{- end -}}
+  {{- /* envSecrets: list of secret names */ -}}
+  {{- range (get $container "envSecrets" | default list) -}}
+    {{- $_ := set $referencedSecrets . true -}}
+  {{- end -}}
+  {{- /* envsFromConfigmap: map keyed by configmap name */ -}}
+  {{- range $configMapName := keys (get $container "envsFromConfigmap" | default dict) -}}
+    {{- $_ := set $referencedConfigMaps $configMapName true -}}
+  {{- end -}}
+  {{- /* envsFromSecret: map keyed by secret name */ -}}
+  {{- range $secretName := keys (get $container "envsFromSecret" | default dict) -}}
+    {{- $_ := set $referencedSecrets $secretName true -}}
+  {{- end -}}
+{{- end -}}
+{{- /* Collect referenced names from workload, general and generic volumes */ -}}
+{{- $volumes := concat ($value.volumes | default list) ($general.volumes | default list) ($ctx.Values.generic.volumes | default list) -}}
+{{- range $vol := $volumes -}}
+  {{- $volType := get $vol "type" | default "" -}}
+  {{- $volName := get $vol "name" | default "" -}}
+  {{- if and (eq $volType "configMap") $volName -}}
+    {{- $_ := set $referencedConfigMaps $volName true -}}
+  {{- end -}}
+  {{- if and (eq $volType "secret") $volName -}}
+    {{- $_ := set $referencedSecrets $volName true -}}
+  {{- end -}}
+{{- end -}}
+configMaps: {{ toJson $referencedConfigMaps }}
+secrets: {{ toJson $referencedSecrets }}
+{{- end -}}
+
 {{- define "helpers.workloads.autoChecksumAnnotations" -}}
 {{- $ctx := .context -}}
 {{- $general := .general | default dict -}}
@@ -231,6 +275,8 @@ false
   {{- end -}}
 {{- end -}}
 {{- if $enabled -}}
+  {{- /* Resolve referenced resources for this workload */ -}}
+  {{- $referencedResources := fromYaml (include "helpers.workloads.referencedResources" (dict "context" $ctx "general" $general "value" $value)) | default dict -}}
   {{- if or (not (empty $ctx.Values.envs)) (not (empty $ctx.Values.envsString)) -}}
     {{- if not (hasKey $reserved "checksum/envs") -}}
       {{- $_ := set $annotations "checksum/envs" (sha256sum (printf "%s\n%s" ($ctx.Values.envs | toYaml) (include "helpers.tplvalues.render" (dict "value" $ctx.Values.envsString "context" $ctx)))) -}}
@@ -242,29 +288,35 @@ false
     {{- end -}}
   {{- end -}}
   {{- range $name := keys ($ctx.Values.configMaps | default dict) | sortAlpha }}
-    {{- $configMap := get $ctx.Values.configMaps $name -}}
-    {{- if eq "true" (include "helpers.resources.isEnabled" (dict "value" $configMap)) -}}
-      {{- $annotationName := printf "checksum/configmap-%s" $name -}}
-      {{- if not (hasKey $reserved $annotationName) -}}
-        {{- $_ := set $annotations $annotationName (sha256sum (($configMap | toYaml) | trim)) -}}
+    {{- if hasKey (get $referencedResources "configMaps" | default dict) $name -}}
+      {{- $configMap := get $ctx.Values.configMaps $name -}}
+      {{- if eq "true" (include "helpers.resources.isEnabled" (dict "value" $configMap)) -}}
+        {{- $annotationName := printf "checksum/configmap-%s" $name -}}
+        {{- if not (hasKey $reserved $annotationName) -}}
+          {{- $_ := set $annotations $annotationName (sha256sum (($configMap | toYaml) | trim)) -}}
+        {{- end -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}
   {{- range $name := keys ($ctx.Values.secrets | default dict) | sortAlpha }}
-    {{- $secret := get $ctx.Values.secrets $name -}}
-    {{- if eq "true" (include "helpers.resources.isEnabled" (dict "value" $secret)) -}}
-      {{- $annotationName := printf "checksum/secret-%s" $name -}}
-      {{- if not (hasKey $reserved $annotationName) -}}
-        {{- $_ := set $annotations $annotationName (sha256sum (($secret | toYaml) | trim)) -}}
+    {{- if hasKey (get $referencedResources "secrets" | default dict) $name -}}
+      {{- $secret := get $ctx.Values.secrets $name -}}
+      {{- if eq "true" (include "helpers.resources.isEnabled" (dict "value" $secret)) -}}
+        {{- $annotationName := printf "checksum/secret-%s" $name -}}
+        {{- if not (hasKey $reserved $annotationName) -}}
+          {{- $_ := set $annotations $annotationName (sha256sum (($secret | toYaml) | trim)) -}}
+        {{- end -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}
   {{- range $name := keys ($ctx.Values.sealedSecrets | default dict) | sortAlpha }}
-    {{- $secret := get $ctx.Values.sealedSecrets $name -}}
-    {{- if eq "true" (include "helpers.resources.isEnabled" (dict "value" $secret)) -}}
-      {{- $annotationName := printf "checksum/sealed-secret-%s" $name -}}
-      {{- if not (hasKey $reserved $annotationName) -}}
-        {{- $_ := set $annotations $annotationName (sha256sum (($secret | toYaml) | trim)) -}}
+    {{- if hasKey (get $referencedResources "secrets" | default dict) $name -}}
+      {{- $secret := get $ctx.Values.sealedSecrets $name -}}
+      {{- if eq "true" (include "helpers.resources.isEnabled" (dict "value" $secret)) -}}
+        {{- $annotationName := printf "checksum/sealed-secret-%s" $name -}}
+        {{- if not (hasKey $reserved $annotationName) -}}
+          {{- $_ := set $annotations $annotationName (sha256sum (($secret | toYaml) | trim)) -}}
+        {{- end -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}

--- a/tests/units/example_daemonset_test.yaml
+++ b/tests/units/example_daemonset_test.yaml
@@ -34,6 +34,8 @@ tests:
           path: spec.template.metadata.labels["workload-tier"]
           value: backend
       - exists:
+          path: spec.template.metadata.annotations["checksum/configmap-shared-config"]
+      - notExists:
           path: spec.template.metadata.annotations["checksum/configmap-app-settings"]
       - equal:
           path: spec.template.spec.topologySpreadConstraints[0].topologyKey

--- a/tests/units/example_pod_test.yaml
+++ b/tests/units/example_pod_test.yaml
@@ -28,6 +28,8 @@ tests:
           path: metadata.annotations["rendered-from"]
           value: values-example
       - exists:
+          path: metadata.annotations["checksum/configmap-shared-config"]
+      - notExists:
           path: metadata.annotations["checksum/secret-app-secret"]
       - equal:
           path: spec.restartPolicy

--- a/tests/units/rendering_contract_test.yaml
+++ b/tests/units/rendering_contract_test.yaml
@@ -235,6 +235,8 @@ tests:
           value: platform-worker
       - exists:
           path: spec.template.metadata.annotations["checksum/configmap-settings"]
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/secret-app"]
 
   - it: renders only enabled HPAs with at least one metric
     values:

--- a/tests/units/values/rendering_contract.values.yaml
+++ b/tests/units/values/rendering_contract.values.yaml
@@ -53,6 +53,10 @@ deployments:
       - name: api
         image: nginx
         imageTag: '{{ .Values.generic.sharedTag }}'
+        envConfigmaps:
+          - settings
+        envSecrets:
+          - app
         env:
           - name: ENVIRONMENT
             value: '{{ .Values.generic.environment }}'
@@ -70,6 +74,8 @@ statefulSets:
       - name: worker
         image: busybox
         imageTag: "1.36.1"
+        envConfigmaps:
+          - settings
         ports:
           - name: tcp
             containerPort: 9000

--- a/values.yaml
+++ b/values.yaml
@@ -50,7 +50,7 @@ generic:
   nameSuffix: ""
   # -- Render deterministic fallback names for unnamed containers and initContainers.
   deterministicNames: true
-  # -- Add checksum annotations for chart-managed ConfigMaps and Secrets to workload pod templates.
+  # -- Add checksum annotations for ConfigMaps and Secrets referenced by each workload to its pod template.
   autoRolloutChecksums: true
   # -- Extra selector labels merged into selectors and workload pod labels.
   extraSelectorLabels: {}


### PR DESCRIPTION
`autoRolloutChecksums` now generates checksum annotations only for ConfigMaps, Secrets, and SealedSecrets that are actually referenced by a given workload (via `envConfigmaps`, `envSecrets`, `envsFromConfigmap`, `envsFromSecret`, or typed `volumes`), instead of checksumming every resource in the release. Global `envs`/`secretEnvs` checksums remain on all workloads