### PR TITLE
feat: support revisionHistoryLimit on Deployments and StatefulSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,13 @@ Schema matching note:
 
 | Field | Example | Default | Description |
 |---|---|---|---|
-| `deploymentsGeneral` | `deploymentsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Deployment entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `progressDeadlineSeconds`. |
+| `deploymentsGeneral` | `deploymentsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Deployment entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `progressDeadlineSeconds`, `revisionHistoryLimit`. |
 | `deployments` | `deployments.api.replicas: 2` | `{}` | Deployment resources keyed by suffix. |
 | `daemonSetsGeneral` | `daemonSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all DaemonSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`. |
 | `daemonSets` | `daemonSets.node-agent.containers.agent.image: busybox` | `{}` | DaemonSet resources keyed by suffix. |
 | `podsGeneral` | `podsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Pod entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields). |
 | `pods` | `pods.toolbox.containers.toolbox.image: busybox` | `{}` | Pod resources keyed by suffix. |
-| `statefulSetsGeneral` | `statefulSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all StatefulSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`, `volumeClaimTemplates`. |
+| `statefulSetsGeneral` | `statefulSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all StatefulSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`, `volumeClaimTemplates`, `revisionHistoryLimit`. |
 | `statefulSets` | `statefulSets.worker.serviceName: headless` | `{}` | StatefulSet resources keyed by suffix. |
 | `jobsGeneral` | `jobsGeneral.backoffLimit: 1` | `{}` | Shared defaults applied to one-shot Jobs. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `parallelism`, `completions`, `activeDeadlineSeconds`, `backoffLimit`, `ttlSecondsAfterFinished`, `restartPolicy`, `commandDurationAlert`, `commandDurationAlertNamespace`. |
 | `jobs` | `jobs.migrate.containers.migrate.image: busybox` | `{}` | One-shot batch jobs keyed by suffix, or one raw templated YAML string. |
@@ -324,6 +324,7 @@ These tables list only fields that are unique to a workload family. Shared knobs
 | `deployments.<name>.replicas` | `replicas: 3` | `1` | Number of desired deployment replicas. |
 | `deployments.<name>.strategy` | `strategy.rollingUpdate.maxUnavailable: 1` | `n/a` | Deployment strategy block. |
 | `deployments.<name>.progressDeadlineSeconds` | `progressDeadlineSeconds: 600` | `600` | Rollout progress deadline in seconds. |
+| `deployments.<name>.revisionHistoryLimit` | `revisionHistoryLimit: 3` | `n/a` | Number of old ReplicaSets retained for rollback. Defaults to the Kubernetes default (10) when unset; falls back to `deploymentsGeneral.revisionHistoryLimit`. |
 
 #### DaemonSets
 
@@ -347,6 +348,7 @@ These tables list only fields that are unique to a workload family. Shared knobs
 | `statefulSets.<name>.serviceName` | `serviceName: headless` | `<resource key>` | Governing service name used by StatefulSet. |
 | `statefulSets.<name>.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Minimum ready time per pod. |
 | `statefulSets.<name>.volumeClaimTemplates` | `volumeClaimTemplates: [{...}]` | `n/a` | PVC templates for StatefulSet pods. |
+| `statefulSets.<name>.revisionHistoryLimit` | `revisionHistoryLimit: 3` | `n/a` | Number of old ControllerRevisions retained for rollback. Defaults to the Kubernetes default (10) when unset; falls back to `statefulSetsGeneral.revisionHistoryLimit`. |
 
 #### Jobs
 
@@ -397,6 +399,7 @@ All [Common Workload Entry Fields](#common-workload-entry-fields) plus:
 |---|---|---|---|
 | `deploymentsGeneral.strategy` | `strategy.type: RollingUpdate` | `n/a` | Default deployment strategy for all Deployments. |
 | `deploymentsGeneral.progressDeadlineSeconds` | `progressDeadlineSeconds: 600` | `n/a` | Default rollout progress deadline in seconds. |
+| `deploymentsGeneral.revisionHistoryLimit` | `revisionHistoryLimit: 3` | `n/a` | Default number of old ReplicaSets retained for all Deployments. |
 
 Example - set default environment sources for every Deployment container:
 
@@ -430,6 +433,7 @@ All [Common Workload Entry Fields](#common-workload-entry-fields) plus:
 | `statefulSetsGeneral.strategy` | `strategy.type: RollingUpdate` | `n/a` | Default update strategy for all StatefulSets. |
 | `statefulSetsGeneral.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Default minimum ready seconds per pod. |
 | `statefulSetsGeneral.volumeClaimTemplates` | `volumeClaimTemplates: [{...}]` | `n/a` | Default PVC templates applied to all StatefulSets. |
+| `statefulSetsGeneral.revisionHistoryLimit` | `revisionHistoryLimit: 3` | `n/a` | Default number of old ControllerRevisions retained for all StatefulSets. |
 
 #### jobsGeneral
 

--- a/docs/README.md.gotmpl
+++ b/docs/README.md.gotmpl
@@ -242,13 +242,13 @@ Schema matching note:
 
 | Field | Example | Default | Description |
 |---|---|---|---|
-| `deploymentsGeneral` | `deploymentsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Deployment entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `progressDeadlineSeconds`. |
+| `deploymentsGeneral` | `deploymentsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Deployment entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `progressDeadlineSeconds`, `revisionHistoryLimit`. |
 | `deployments` | `deployments.api.replicas: 2` | `{}` | Deployment resources keyed by suffix. |
 | `daemonSetsGeneral` | `daemonSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all DaemonSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`. |
 | `daemonSets` | `daemonSets.node-agent.containers.agent.image: busybox` | `{}` | DaemonSet resources keyed by suffix. |
 | `podsGeneral` | `podsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Pod entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields). |
 | `pods` | `pods.toolbox.containers.toolbox.image: busybox` | `{}` | Pod resources keyed by suffix. |
-| `statefulSetsGeneral` | `statefulSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all StatefulSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`, `volumeClaimTemplates`. |
+| `statefulSetsGeneral` | `statefulSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all StatefulSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`, `volumeClaimTemplates`, `revisionHistoryLimit`. |
 | `statefulSets` | `statefulSets.worker.serviceName: headless` | `{}` | StatefulSet resources keyed by suffix. |
 | `jobsGeneral` | `jobsGeneral.backoffLimit: 1` | `{}` | Shared defaults applied to one-shot Jobs. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `parallelism`, `completions`, `activeDeadlineSeconds`, `backoffLimit`, `ttlSecondsAfterFinished`, `restartPolicy`, `commandDurationAlert`, `commandDurationAlertNamespace`. |
 | `jobs` | `jobs.migrate.containers.migrate.image: busybox` | `{}` | One-shot batch jobs keyed by suffix, or one raw templated YAML string. |
@@ -322,6 +322,7 @@ These tables list only fields that are unique to a workload family. Shared knobs
 | `deployments.<name>.replicas` | `replicas: 3` | `1` | Number of desired deployment replicas. |
 | `deployments.<name>.strategy` | `strategy.rollingUpdate.maxUnavailable: 1` | `n/a` | Deployment strategy block. |
 | `deployments.<name>.progressDeadlineSeconds` | `progressDeadlineSeconds: 600` | `600` | Rollout progress deadline in seconds. |
+| `deployments.<name>.revisionHistoryLimit` | `revisionHistoryLimit: 3` | `n/a` | Number of old ReplicaSets retained for rollback. Defaults to the Kubernetes default (10) when unset; falls back to `deploymentsGeneral.revisionHistoryLimit`. |
 
 #### DaemonSets
 
@@ -345,6 +346,7 @@ These tables list only fields that are unique to a workload family. Shared knobs
 | `statefulSets.<name>.serviceName` | `serviceName: headless` | `<resource key>` | Governing service name used by StatefulSet. |
 | `statefulSets.<name>.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Minimum ready time per pod. |
 | `statefulSets.<name>.volumeClaimTemplates` | `volumeClaimTemplates: [{...}]` | `n/a` | PVC templates for StatefulSet pods. |
+| `statefulSets.<name>.revisionHistoryLimit` | `revisionHistoryLimit: 3` | `n/a` | Number of old ControllerRevisions retained for rollback. Defaults to the Kubernetes default (10) when unset; falls back to `statefulSetsGeneral.revisionHistoryLimit`. |
 
 #### Jobs
 
@@ -395,6 +397,7 @@ All [Common Workload Entry Fields](#common-workload-entry-fields) plus:
 |---|---|---|---|
 | `deploymentsGeneral.strategy` | `strategy.type: RollingUpdate` | `n/a` | Default deployment strategy for all Deployments. |
 | `deploymentsGeneral.progressDeadlineSeconds` | `progressDeadlineSeconds: 600` | `n/a` | Default rollout progress deadline in seconds. |
+| `deploymentsGeneral.revisionHistoryLimit` | `revisionHistoryLimit: 3` | `n/a` | Default number of old ReplicaSets retained for all Deployments. |
 
 Example - set default environment sources for every Deployment container:
 
@@ -428,6 +431,7 @@ All [Common Workload Entry Fields](#common-workload-entry-fields) plus:
 | `statefulSetsGeneral.strategy` | `strategy.type: RollingUpdate` | `n/a` | Default update strategy for all StatefulSets. |
 | `statefulSetsGeneral.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Default minimum ready seconds per pod. |
 | `statefulSetsGeneral.volumeClaimTemplates` | `volumeClaimTemplates: [{...}]` | `n/a` | Default PVC templates applied to all StatefulSets. |
+| `statefulSetsGeneral.revisionHistoryLimit` | `revisionHistoryLimit: 3` | `n/a` | Default number of old ControllerRevisions retained for all StatefulSets. |
 
 #### jobsGeneral
 

--- a/templates/workloads/deployment.yml
+++ b/templates/workloads/deployment.yml
@@ -23,6 +23,11 @@ spec:
   strategy: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}
   progressDeadlineSeconds: {{ $deployment.progressDeadlineSeconds | default 600 }}
+  {{- if hasKey $deployment "revisionHistoryLimit" }}
+  revisionHistoryLimit: {{ get $deployment "revisionHistoryLimit" }}
+  {{- else if hasKey $general "revisionHistoryLimit" }}
+  revisionHistoryLimit: {{ get $general "revisionHistoryLimit" }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "helpers.app.selectorLabels" $ | nindent 6 }}

--- a/templates/workloads/statefulset.yml
+++ b/templates/workloads/statefulset.yml
@@ -26,6 +26,11 @@ spec:
   {{- with $statefulSet.minReadySeconds }}
   minReadySeconds: {{ . }}
   {{- end }}
+  {{- if hasKey $statefulSet "revisionHistoryLimit" }}
+  revisionHistoryLimit: {{ get $statefulSet "revisionHistoryLimit" }}
+  {{- else if hasKey $general "revisionHistoryLimit" }}
+  revisionHistoryLimit: {{ get $general "revisionHistoryLimit" }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "helpers.app.selectorLabels" $ | nindent 6 }}

--- a/tests/units/revision_history_limit_test.yaml
+++ b/tests/units/revision_history_limit_test.yaml
@@ -1,0 +1,97 @@
+suite: revisionHistoryLimit
+templates:
+  - templates/workloads/deployment.yml
+  - templates/workloads/statefulset.yml
+release:
+  name: smoke-test
+  namespace: default
+
+tests:
+  - it: omits revisionHistoryLimit on a Deployment when neither workload nor general sets it
+    template: templates/workloads/deployment.yml
+    set:
+      deployments.app.containers.main.image: nginx:1.27.5
+    asserts:
+      - notExists:
+          path: spec.revisionHistoryLimit
+
+  - it: renders the per-Deployment revisionHistoryLimit
+    template: templates/workloads/deployment.yml
+    set:
+      deployments.app.revisionHistoryLimit: 2
+      deployments.app.containers.main.image: nginx:1.27.5
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 2
+
+  - it: falls back to deploymentsGeneral.revisionHistoryLimit when the workload omits it
+    template: templates/workloads/deployment.yml
+    set:
+      deploymentsGeneral.revisionHistoryLimit: 5
+      deployments.app.containers.main.image: nginx:1.27.5
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 5
+
+  - it: per-Deployment revisionHistoryLimit overrides the general fallback
+    template: templates/workloads/deployment.yml
+    set:
+      deploymentsGeneral.revisionHistoryLimit: 5
+      deployments.app.revisionHistoryLimit: 2
+      deployments.app.containers.main.image: nginx:1.27.5
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 2
+
+  - it: honours an explicit revisionHistoryLimit of 0 on a Deployment
+    template: templates/workloads/deployment.yml
+    set:
+      deploymentsGeneral.revisionHistoryLimit: 5
+      deployments.app.revisionHistoryLimit: 0
+      deployments.app.containers.main.image: nginx:1.27.5
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 0
+
+  - it: omits revisionHistoryLimit on a StatefulSet when neither workload nor general sets it
+    template: templates/workloads/statefulset.yml
+    set:
+      statefulSets.app.containers.main.image: nginx:1.27.5
+    asserts:
+      - notExists:
+          path: spec.revisionHistoryLimit
+
+  - it: renders the per-StatefulSet revisionHistoryLimit
+    template: templates/workloads/statefulset.yml
+    set:
+      statefulSets.app.revisionHistoryLimit: 3
+      statefulSets.app.containers.main.image: nginx:1.27.5
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 3
+
+  - it: falls back to statefulSetsGeneral.revisionHistoryLimit when the workload omits it
+    template: templates/workloads/statefulset.yml
+    set:
+      statefulSetsGeneral.revisionHistoryLimit: 4
+      statefulSets.app.containers.main.image: nginx:1.27.5
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 4
+
+  - it: per-StatefulSet revisionHistoryLimit (including an explicit 0) overrides the general fallback
+    template: templates/workloads/statefulset.yml
+    set:
+      statefulSetsGeneral.revisionHistoryLimit: 4
+      statefulSets.app.revisionHistoryLimit: 0
+      statefulSets.app.containers.main.image: nginx:1.27.5
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 0

--- a/values.schema.json
+++ b/values.schema.json
@@ -1426,6 +1426,9 @@
             },
             "progressDeadlineSeconds": {
               "type": "integer"
+            },
+            "revisionHistoryLimit": {
+              "type": "integer"
             }
           }
         }
@@ -1444,6 +1447,9 @@
               "$ref": "#/definitions/freeFormObject"
             },
             "progressDeadlineSeconds": {
+              "type": "integer"
+            },
+            "revisionHistoryLimit": {
               "type": "integer"
             }
           }
@@ -1547,6 +1553,9 @@
             },
             "volumeClaimTemplates": {
               "$ref": "#/definitions/freeFormArray"
+            },
+            "revisionHistoryLimit": {
+              "type": "integer"
             }
           }
         }
@@ -1569,6 +1578,9 @@
             },
             "volumeClaimTemplates": {
               "$ref": "#/definitions/freeFormArray"
+            },
+            "revisionHistoryLimit": {
+              "type": "integer"
             }
           }
         }


### PR DESCRIPTION
Closes #120

**What.** Adds an optional `revisionHistoryLimit` field to Deployment and StatefulSet workload entries and their `*General` defaults:
- `deployments.<name>.revisionHistoryLimit` / `deploymentsGeneral.revisionHistoryLimit`
- `statefulSets.<name>.revisionHistoryLimit` / `statefulSetsGeneral.revisionHistoryLimit`

**Why.** Without it the Kubernetes default (10) applies, so frequent rollouts pile up dozens of old ReplicaSets / ControllerRevisions and clutter UIs such as the Argo CD resource tree. The field lets operators cap the retained history.