### PR TITLE
nxs-universal-chart: add revisionHistoryLimit support for Deployments, DaemonSets and StatefulSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Added
+* added `revisionHistoryLimit` support for `deployments`, `daemonSets`, and `statefulSets` entries with `deploymentsGeneral`/`daemonSetsGeneral`/`statefulSetsGeneral` defaults, so the number of retained old ReplicaSets/ControllerRevisions can be limited (Kubernetes keeps `10` by default).
+
 ## [3.1.0] - May 27, 2026
 ### Fixed
 * fixed `nuc-native-gateway` (`1.0.6`): `spec` of HTTPRoute (and all other Gateway API resources) was rendered as-is via `toYaml`, so Helm template expressions in string values — e.g. `'{{ printf "%s-%s" .Release.Name "frontend" }}'` or `'{{ include "helpers.app.fullname" … }}'` — were not evaluated. `spec` and `status` are now rendered through `tpl`, making release-name-aware `backendRefs` work out of the box.

--- a/README.md
+++ b/README.md
@@ -244,13 +244,13 @@ Schema matching note:
 
 | Field | Example | Default | Description |
 |---|---|---|---|
-| `deploymentsGeneral` | `deploymentsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Deployment entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `progressDeadlineSeconds`. |
+| `deploymentsGeneral` | `deploymentsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Deployment entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `progressDeadlineSeconds`, `revisionHistoryLimit`. |
 | `deployments` | `deployments.api.replicas: 2` | `{}` | Deployment resources keyed by suffix. |
-| `daemonSetsGeneral` | `daemonSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all DaemonSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`. |
+| `daemonSetsGeneral` | `daemonSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all DaemonSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`, `revisionHistoryLimit`. |
 | `daemonSets` | `daemonSets.node-agent.containers.agent.image: busybox` | `{}` | DaemonSet resources keyed by suffix. |
 | `podsGeneral` | `podsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Pod entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields). |
 | `pods` | `pods.toolbox.containers.toolbox.image: busybox` | `{}` | Pod resources keyed by suffix. |
-| `statefulSetsGeneral` | `statefulSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all StatefulSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`, `volumeClaimTemplates`. |
+| `statefulSetsGeneral` | `statefulSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all StatefulSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`, `revisionHistoryLimit`, `volumeClaimTemplates`. |
 | `statefulSets` | `statefulSets.worker.serviceName: headless` | `{}` | StatefulSet resources keyed by suffix. |
 | `jobsGeneral` | `jobsGeneral.backoffLimit: 1` | `{}` | Shared defaults applied to one-shot Jobs. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `parallelism`, `completions`, `activeDeadlineSeconds`, `backoffLimit`, `ttlSecondsAfterFinished`, `restartPolicy`, `commandDurationAlert`, `commandDurationAlertNamespace`. |
 | `jobs` | `jobs.migrate.containers.migrate.image: busybox` | `{}` | One-shot batch jobs keyed by suffix, or one raw templated YAML string. |
@@ -324,6 +324,7 @@ These tables list only fields that are unique to a workload family. Shared knobs
 | `deployments.<name>.replicas` | `replicas: 3` | `1` | Number of desired deployment replicas. |
 | `deployments.<name>.strategy` | `strategy.rollingUpdate.maxUnavailable: 1` | `n/a` | Deployment strategy block. |
 | `deployments.<name>.progressDeadlineSeconds` | `progressDeadlineSeconds: 600` | `600` | Rollout progress deadline in seconds. |
+| `deployments.<name>.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Number of old ReplicaSets retained for rollback. Falls back to `deploymentsGeneral.revisionHistoryLimit`; omitted by default (Kubernetes default is `10`). |
 
 #### DaemonSets
 
@@ -331,6 +332,7 @@ These tables list only fields that are unique to a workload family. Shared knobs
 |---|---|---|---|
 | `daemonSets.<name>.strategy` | `strategy.type: RollingUpdate` | `n/a` | DaemonSet update strategy. |
 | `daemonSets.<name>.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Minimum seconds for pod readiness before considered available. |
+| `daemonSets.<name>.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Number of old ControllerRevisions retained for rollback. Falls back to `daemonSetsGeneral.revisionHistoryLimit`; omitted by default (Kubernetes default is `10`). |
 
 #### Pods
 
@@ -346,6 +348,7 @@ These tables list only fields that are unique to a workload family. Shared knobs
 | `statefulSets.<name>.strategy` | `strategy.type: RollingUpdate` | `n/a` | StatefulSet update strategy. |
 | `statefulSets.<name>.serviceName` | `serviceName: headless` | `<resource key>` | Governing service name used by StatefulSet. |
 | `statefulSets.<name>.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Minimum ready time per pod. |
+| `statefulSets.<name>.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Number of old ControllerRevisions retained for rollback. Falls back to `statefulSetsGeneral.revisionHistoryLimit`; omitted by default (Kubernetes default is `10`). |
 | `statefulSets.<name>.volumeClaimTemplates` | `volumeClaimTemplates: [{...}]` | `n/a` | PVC templates for StatefulSet pods. |
 
 #### Jobs
@@ -397,6 +400,7 @@ All [Common Workload Entry Fields](#common-workload-entry-fields) plus:
 |---|---|---|---|
 | `deploymentsGeneral.strategy` | `strategy.type: RollingUpdate` | `n/a` | Default deployment strategy for all Deployments. |
 | `deploymentsGeneral.progressDeadlineSeconds` | `progressDeadlineSeconds: 600` | `n/a` | Default rollout progress deadline in seconds. |
+| `deploymentsGeneral.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Default number of old ReplicaSets retained for all Deployments. |
 
 Example - set default environment sources for every Deployment container:
 
@@ -416,6 +420,7 @@ All [Common Workload Entry Fields](#common-workload-entry-fields) plus:
 |---|---|---|---|
 | `daemonSetsGeneral.strategy` | `strategy.type: RollingUpdate` | `n/a` | Default update strategy for all DaemonSets. |
 | `daemonSetsGeneral.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Default minimum ready seconds before pod is considered available. |
+| `daemonSetsGeneral.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Default number of old ControllerRevisions retained for all DaemonSets. |
 
 #### podsGeneral
 
@@ -429,6 +434,7 @@ All [Common Workload Entry Fields](#common-workload-entry-fields) plus:
 |---|---|---|---|
 | `statefulSetsGeneral.strategy` | `strategy.type: RollingUpdate` | `n/a` | Default update strategy for all StatefulSets. |
 | `statefulSetsGeneral.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Default minimum ready seconds per pod. |
+| `statefulSetsGeneral.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Default number of old ControllerRevisions retained for all StatefulSets. |
 | `statefulSetsGeneral.volumeClaimTemplates` | `volumeClaimTemplates: [{...}]` | `n/a` | Default PVC templates applied to all StatefulSets. |
 
 #### jobsGeneral

--- a/docs/README.md.gotmpl
+++ b/docs/README.md.gotmpl
@@ -242,13 +242,13 @@ Schema matching note:
 
 | Field | Example | Default | Description |
 |---|---|---|---|
-| `deploymentsGeneral` | `deploymentsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Deployment entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `progressDeadlineSeconds`. |
+| `deploymentsGeneral` | `deploymentsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Deployment entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `progressDeadlineSeconds`, `revisionHistoryLimit`. |
 | `deployments` | `deployments.api.replicas: 2` | `{}` | Deployment resources keyed by suffix. |
-| `daemonSetsGeneral` | `daemonSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all DaemonSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`. |
+| `daemonSetsGeneral` | `daemonSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all DaemonSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`, `revisionHistoryLimit`. |
 | `daemonSets` | `daemonSets.node-agent.containers.agent.image: busybox` | `{}` | DaemonSet resources keyed by suffix. |
 | `podsGeneral` | `podsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all Pod entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields). |
 | `pods` | `pods.toolbox.containers.toolbox.image: busybox` | `{}` | Pod resources keyed by suffix. |
-| `statefulSetsGeneral` | `statefulSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all StatefulSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`, `volumeClaimTemplates`. |
+| `statefulSetsGeneral` | `statefulSetsGeneral.resources.requests.cpu: 100m` | `{}` | Shared defaults applied to all StatefulSet entries. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `strategy`, `minReadySeconds`, `revisionHistoryLimit`, `volumeClaimTemplates`. |
 | `statefulSets` | `statefulSets.worker.serviceName: headless` | `{}` | StatefulSet resources keyed by suffix. |
 | `jobsGeneral` | `jobsGeneral.backoffLimit: 1` | `{}` | Shared defaults applied to one-shot Jobs. Supports all [Common Workload Entry Fields](#common-workload-entry-fields) plus `parallelism`, `completions`, `activeDeadlineSeconds`, `backoffLimit`, `ttlSecondsAfterFinished`, `restartPolicy`, `commandDurationAlert`, `commandDurationAlertNamespace`. |
 | `jobs` | `jobs.migrate.containers.migrate.image: busybox` | `{}` | One-shot batch jobs keyed by suffix, or one raw templated YAML string. |
@@ -322,6 +322,7 @@ These tables list only fields that are unique to a workload family. Shared knobs
 | `deployments.<name>.replicas` | `replicas: 3` | `1` | Number of desired deployment replicas. |
 | `deployments.<name>.strategy` | `strategy.rollingUpdate.maxUnavailable: 1` | `n/a` | Deployment strategy block. |
 | `deployments.<name>.progressDeadlineSeconds` | `progressDeadlineSeconds: 600` | `600` | Rollout progress deadline in seconds. |
+| `deployments.<name>.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Number of old ReplicaSets retained for rollback. Falls back to `deploymentsGeneral.revisionHistoryLimit`; omitted by default (Kubernetes default is `10`). |
 
 #### DaemonSets
 
@@ -329,6 +330,7 @@ These tables list only fields that are unique to a workload family. Shared knobs
 |---|---|---|---|
 | `daemonSets.<name>.strategy` | `strategy.type: RollingUpdate` | `n/a` | DaemonSet update strategy. |
 | `daemonSets.<name>.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Minimum seconds for pod readiness before considered available. |
+| `daemonSets.<name>.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Number of old ControllerRevisions retained for rollback. Falls back to `daemonSetsGeneral.revisionHistoryLimit`; omitted by default (Kubernetes default is `10`). |
 
 #### Pods
 
@@ -344,6 +346,7 @@ These tables list only fields that are unique to a workload family. Shared knobs
 | `statefulSets.<name>.strategy` | `strategy.type: RollingUpdate` | `n/a` | StatefulSet update strategy. |
 | `statefulSets.<name>.serviceName` | `serviceName: headless` | `<resource key>` | Governing service name used by StatefulSet. |
 | `statefulSets.<name>.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Minimum ready time per pod. |
+| `statefulSets.<name>.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Number of old ControllerRevisions retained for rollback. Falls back to `statefulSetsGeneral.revisionHistoryLimit`; omitted by default (Kubernetes default is `10`). |
 | `statefulSets.<name>.volumeClaimTemplates` | `volumeClaimTemplates: [{...}]` | `n/a` | PVC templates for StatefulSet pods. |
 
 #### Jobs
@@ -395,6 +398,7 @@ All [Common Workload Entry Fields](#common-workload-entry-fields) plus:
 |---|---|---|---|
 | `deploymentsGeneral.strategy` | `strategy.type: RollingUpdate` | `n/a` | Default deployment strategy for all Deployments. |
 | `deploymentsGeneral.progressDeadlineSeconds` | `progressDeadlineSeconds: 600` | `n/a` | Default rollout progress deadline in seconds. |
+| `deploymentsGeneral.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Default number of old ReplicaSets retained for all Deployments. |
 
 Example - set default environment sources for every Deployment container:
 
@@ -414,6 +418,7 @@ All [Common Workload Entry Fields](#common-workload-entry-fields) plus:
 |---|---|---|---|
 | `daemonSetsGeneral.strategy` | `strategy.type: RollingUpdate` | `n/a` | Default update strategy for all DaemonSets. |
 | `daemonSetsGeneral.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Default minimum ready seconds before pod is considered available. |
+| `daemonSetsGeneral.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Default number of old ControllerRevisions retained for all DaemonSets. |
 
 #### podsGeneral
 
@@ -427,6 +432,7 @@ All [Common Workload Entry Fields](#common-workload-entry-fields) plus:
 |---|---|---|---|
 | `statefulSetsGeneral.strategy` | `strategy.type: RollingUpdate` | `n/a` | Default update strategy for all StatefulSets. |
 | `statefulSetsGeneral.minReadySeconds` | `minReadySeconds: 10` | `n/a` | Default minimum ready seconds per pod. |
+| `statefulSetsGeneral.revisionHistoryLimit` | `revisionHistoryLimit: 2` | `n/a` | Default number of old ControllerRevisions retained for all StatefulSets. |
 | `statefulSetsGeneral.volumeClaimTemplates` | `volumeClaimTemplates: [{...}]` | `n/a` | Default PVC templates applied to all StatefulSets. |
 
 #### jobsGeneral

--- a/templates/workloads/daemonset.yml
+++ b/templates/workloads/daemonset.yml
@@ -4,6 +4,20 @@
 {{- range $name := keys (.Values.daemonSets | default dict) | sortAlpha }}
 {{- $daemonSet := get $.Values.daemonSets $name -}}
 {{- if eq "true" (include "helpers.resources.isEnabled" (dict "value" $daemonSet)) }}
+{{- $revisionHistoryLimitSet := false -}}
+{{- $revisionHistoryLimit := 0 -}}
+{{- if and (hasKey $general "revisionHistoryLimit") (ne $general.revisionHistoryLimit nil) -}}
+  {{- $revisionHistoryLimit = $general.revisionHistoryLimit -}}
+  {{- $revisionHistoryLimitSet = true -}}
+{{- end -}}
+{{- if hasKey $daemonSet "revisionHistoryLimit" -}}
+  {{- if ne $daemonSet.revisionHistoryLimit nil -}}
+    {{- $revisionHistoryLimit = $daemonSet.revisionHistoryLimit -}}
+    {{- $revisionHistoryLimitSet = true -}}
+  {{- else -}}
+    {{- $revisionHistoryLimitSet = false -}}
+  {{- end -}}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -18,6 +32,9 @@ metadata:
   annotations:
     {{- include "helpers.app.annotations" (dict "context" $ "general" $general "value" $daemonSet) | nindent 4 }}
 spec:
+  {{- if $revisionHistoryLimitSet }}
+  revisionHistoryLimit: {{ $revisionHistoryLimit }}
+  {{- end }}
   {{- with $daemonSet.strategy }}
   updateStrategy: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}

--- a/templates/workloads/deployment.yml
+++ b/templates/workloads/deployment.yml
@@ -4,6 +4,20 @@
 {{- range $name := keys (.Values.deployments | default dict) | sortAlpha }}
 {{- $deployment := get $.Values.deployments $name -}}
 {{- if eq "true" (include "helpers.resources.isEnabled" (dict "value" $deployment)) }}
+{{- $revisionHistoryLimitSet := false -}}
+{{- $revisionHistoryLimit := 0 -}}
+{{- if and (hasKey $general "revisionHistoryLimit") (ne $general.revisionHistoryLimit nil) -}}
+  {{- $revisionHistoryLimit = $general.revisionHistoryLimit -}}
+  {{- $revisionHistoryLimitSet = true -}}
+{{- end -}}
+{{- if hasKey $deployment "revisionHistoryLimit" -}}
+  {{- if ne $deployment.revisionHistoryLimit nil -}}
+    {{- $revisionHistoryLimit = $deployment.revisionHistoryLimit -}}
+    {{- $revisionHistoryLimitSet = true -}}
+  {{- else -}}
+    {{- $revisionHistoryLimitSet = false -}}
+  {{- end -}}
+{{- end }}
 ---
 apiVersion: {{ include "helpers.capabilities.deployment.apiVersion" $ }}
 kind: Deployment
@@ -19,6 +33,9 @@ metadata:
     {{- include "helpers.app.annotations" (dict "context" $ "general" $general "value" $deployment) | nindent 4 }}
 spec:
   replicas: {{ $deployment.replicas | default 1 }}
+  {{- if $revisionHistoryLimitSet }}
+  revisionHistoryLimit: {{ $revisionHistoryLimit }}
+  {{- end }}
   {{- with $deployment.strategy }}
   strategy: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}

--- a/templates/workloads/statefulset.yml
+++ b/templates/workloads/statefulset.yml
@@ -4,6 +4,20 @@
 {{- range $name := keys (.Values.statefulSets | default dict) | sortAlpha }}
 {{- $statefulSet := get $.Values.statefulSets $name -}}
 {{- if eq "true" (include "helpers.resources.isEnabled" (dict "value" $statefulSet)) }}
+{{- $revisionHistoryLimitSet := false -}}
+{{- $revisionHistoryLimit := 0 -}}
+{{- if and (hasKey $general "revisionHistoryLimit") (ne $general.revisionHistoryLimit nil) -}}
+  {{- $revisionHistoryLimit = $general.revisionHistoryLimit -}}
+  {{- $revisionHistoryLimitSet = true -}}
+{{- end -}}
+{{- if hasKey $statefulSet "revisionHistoryLimit" -}}
+  {{- if ne $statefulSet.revisionHistoryLimit nil -}}
+    {{- $revisionHistoryLimit = $statefulSet.revisionHistoryLimit -}}
+    {{- $revisionHistoryLimitSet = true -}}
+  {{- else -}}
+    {{- $revisionHistoryLimitSet = false -}}
+  {{- end -}}
+{{- end }}
 ---
 apiVersion: {{ include "helpers.capabilities.statefulSet.apiVersion" $ }}
 kind: StatefulSet
@@ -19,6 +33,9 @@ metadata:
     {{- include "helpers.app.annotations" (dict "context" $ "general" $general "value" $statefulSet) | nindent 4 }}
 spec:
   replicas: {{ $statefulSet.replicas | default 1 }}
+  {{- if $revisionHistoryLimitSet }}
+  revisionHistoryLimit: {{ $revisionHistoryLimit }}
+  {{- end }}
   {{- with $statefulSet.strategy }}
   strategy: {{- include "helpers.tplvalues.render" (dict "value" . "context" $) | nindent 4 }}
   {{- end }}

--- a/tests/units/example_deployment_test.yaml
+++ b/tests/units/example_deployment_test.yaml
@@ -37,6 +37,9 @@ tests:
           path: spec.replicas
           value: 2
       - equal:
+          path: spec.revisionHistoryLimit
+          value: 2
+      - equal:
           path: spec.selector.matchLabels.tenant
           value: shared
       - equal:

--- a/tests/units/revision_history_limit_test.yaml
+++ b/tests/units/revision_history_limit_test.yaml
@@ -1,0 +1,117 @@
+suite: revision history limit
+templates:
+  - templates/workloads/deployment.yml
+  - templates/workloads/daemonset.yml
+  - templates/workloads/statefulset.yml
+release:
+  name: unit-test
+  namespace: unit-namespace
+
+tests:
+  - it: omits revisionHistoryLimit by default
+    values:
+      - values/revision_history_limit.values.yaml
+    template: templates/workloads/deployment.yml
+    asserts:
+      - notExists:
+          path: spec.revisionHistoryLimit
+
+  - it: renders per-deployment revisionHistoryLimit
+    values:
+      - values/revision_history_limit.values.yaml
+    set:
+      deployments.app.revisionHistoryLimit: 3
+    template: templates/workloads/deployment.yml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 3
+
+  - it: preserves explicit zero revisionHistoryLimit
+    values:
+      - values/revision_history_limit.values.yaml
+    set:
+      deployments.app.revisionHistoryLimit: 0
+    template: templates/workloads/deployment.yml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 0
+
+  - it: inherits revisionHistoryLimit from deploymentsGeneral
+    values:
+      - values/revision_history_limit.values.yaml
+    set:
+      deploymentsGeneral.revisionHistoryLimit: 5
+    template: templates/workloads/deployment.yml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 5
+
+  - it: prefers per-deployment revisionHistoryLimit over deploymentsGeneral
+    values:
+      - values/revision_history_limit.values.yaml
+    set:
+      deploymentsGeneral.revisionHistoryLimit: 5
+      deployments.app.revisionHistoryLimit: 2
+    template: templates/workloads/deployment.yml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 2
+
+  - it: clears general revisionHistoryLimit with explicit null
+    values:
+      - values/revision_history_limit.values.yaml
+    set:
+      deploymentsGeneral.revisionHistoryLimit: 5
+      deployments.app.revisionHistoryLimit: null
+    template: templates/workloads/deployment.yml
+    asserts:
+      - notExists:
+          path: spec.revisionHistoryLimit
+
+  - it: renders per-daemonset revisionHistoryLimit
+    values:
+      - values/revision_history_limit.values.yaml
+    set:
+      daemonSets.agent.revisionHistoryLimit: 4
+    template: templates/workloads/daemonset.yml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 4
+
+  - it: inherits revisionHistoryLimit from daemonSetsGeneral
+    values:
+      - values/revision_history_limit.values.yaml
+    set:
+      daemonSetsGeneral.revisionHistoryLimit: 5
+    template: templates/workloads/daemonset.yml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 5
+
+  - it: renders per-statefulset revisionHistoryLimit
+    values:
+      - values/revision_history_limit.values.yaml
+    set:
+      statefulSets.db.revisionHistoryLimit: 4
+    template: templates/workloads/statefulset.yml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 4
+
+  - it: inherits revisionHistoryLimit from statefulSetsGeneral
+    values:
+      - values/revision_history_limit.values.yaml
+    set:
+      statefulSetsGeneral.revisionHistoryLimit: 5
+    template: templates/workloads/statefulset.yml
+    asserts:
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 5

--- a/tests/units/values/revision_history_limit.values.yaml
+++ b/tests/units/values/revision_history_limit.values.yaml
@@ -1,0 +1,20 @@
+deployments:
+  app:
+    containers:
+      app:
+        image: nginx
+        imageTag: "1.27.5"
+
+daemonSets:
+  agent:
+    containers:
+      agent:
+        image: nginx
+        imageTag: "1.27.5"
+
+statefulSets:
+  db:
+    containers:
+      db:
+        image: nginx
+        imageTag: "1.27.5"

--- a/values.schema.json
+++ b/values.schema.json
@@ -1426,6 +1426,10 @@
             },
             "progressDeadlineSeconds": {
               "type": "integer"
+            },
+            "revisionHistoryLimit": {
+              "type": ["integer", "null"],
+              "minimum": 0
             }
           }
         }
@@ -1445,6 +1449,10 @@
             },
             "progressDeadlineSeconds": {
               "type": "integer"
+            },
+            "revisionHistoryLimit": {
+              "type": ["integer", "null"],
+              "minimum": 0
             }
           }
         }
@@ -1472,6 +1480,10 @@
             "minReadySeconds": {
               "type": "integer"
             },
+            "revisionHistoryLimit": {
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
             "strategy": {
               "$ref": "#/definitions/freeFormObject"
             }
@@ -1490,6 +1502,10 @@
           "properties": {
             "minReadySeconds": {
               "type": "integer"
+            },
+            "revisionHistoryLimit": {
+              "type": ["integer", "null"],
+              "minimum": 0
             },
             "strategy": {
               "$ref": "#/definitions/freeFormObject"
@@ -1545,6 +1561,10 @@
             "minReadySeconds": {
               "type": "integer"
             },
+            "revisionHistoryLimit": {
+              "type": ["integer", "null"],
+              "minimum": 0
+            },
             "volumeClaimTemplates": {
               "$ref": "#/definitions/freeFormArray"
             }
@@ -1566,6 +1586,10 @@
             },
             "minReadySeconds": {
               "type": "integer"
+            },
+            "revisionHistoryLimit": {
+              "type": ["integer", "null"],
+              "minimum": 0
             },
             "volumeClaimTemplates": {
               "$ref": "#/definitions/freeFormArray"

--- a/values.yaml.example
+++ b/values.yaml.example
@@ -152,6 +152,7 @@ deployments:
         syncOptions:
           - ServerSideApply=true
     replicas: 2
+    revisionHistoryLimit: 2
     extraSelectorLabels:
       component: api
     serviceAccountName: deployer


### PR DESCRIPTION
#### What this PR does / why we need it

Adds `revisionHistoryLimit` support for `deployments`, `daemonSets`, and `statefulSets`.

Today the chart renders these workloads without `spec.revisionHistoryLimit`, so Kubernetes keeps its default of 10 old ReplicaSets per Deployment (and 10 ControllerRevisions per DaemonSet/StatefulSet), and there is no way to limit this via values. On clusters with many releases and frequent rollouts this piles up thousands of stale ReplicaSet objects.

The field can now be set per workload entry and as a family-wide default:

```yaml
deploymentsGeneral:
  revisionHistoryLimit: 2

deployments:
  api:
    revisionHistoryLimit: 5   # overrides the general default
  worker: {}                  # inherits 2 from deploymentsGeneral
```

Semantics follow the existing `cronJobsGeneral.suspend` idiom: a per-entry value overrides the `*General` default, an explicit `null` on the entry clears the general default (falling back to the Kubernetes default), `0` is preserved, and when nothing is set the field is omitted so rendered manifests stay byte-identical to previous chart versions.

#### Which issue this PR fixes

- n/a

#### Special notes for your reviewer

- Schema allows `integer >= 0` or `null` (null enables the explicit per-entry reset, same as `suspend`).
- Verified locally: `helm lint . -f values.yaml.example`, `helm template` with the example values, `helm unittest` (31 suites / 100 tests passed, including the new `revision_history_limit_test.yaml`), and `tests/smokes/run/smoke.py --scenario default-empty --scenario rendering-contract --scenario example-render`.
- Chart version left untouched since releases appear to bump it in dedicated release PRs; happy to bump if you prefer it in-PR.

#### Checklist

- [ ] Chart version bumped in `Chart.yaml` if needed
- [x] `CHANGELOG.md` updated if needed
- [x] Tests added or updated for the changed behavior
- [x] Documentation updated where relevant
- [x] Pull request title starts with `nxs-universal-chart:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
